### PR TITLE
feat: add reusable Go build + attestation workflow

### DIFF
--- a/.github/workflows/build-go-attest.yml
+++ b/.github/workflows/build-go-attest.yml
@@ -20,6 +20,11 @@ on:
         required: false
         type: string
         default: ""
+      cgo-enabled:
+        description: "Enable CGO (0=disabled, 1=enabled)"
+        required: false
+        type: string
+        default: "0"
       go-version-file:
         description: "Path to go.mod or .go-version for Go version detection"
         required: false
@@ -46,8 +51,9 @@ on:
         type: boolean
         default: true
 
+# Least privilege: only request write permissions for jobs that need them
 permissions:
-  contents: write
+  contents: read
   id-token: write
   attestations: write
 
@@ -55,6 +61,10 @@ jobs:
   build:
     name: Build and Attest
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
@@ -63,6 +73,8 @@ jobs:
 
       - name: Checkout caller repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -71,15 +83,25 @@ jobs:
 
       - name: Build binary
         env:
-          CGO_ENABLED: "0"
+          CGO_ENABLED: ${{ inputs.cgo-enabled }}
           GOOS: ${{ inputs.goos }}
           GOARCH: ${{ inputs.goarch }}
-          GOARM: ${{ inputs.goarm }}
           BINARY_NAME: ${{ inputs.binary-name }}
           LDFLAGS: ${{ inputs.ldflags }}
           MAIN_PACKAGE: ${{ inputs.main-package }}
+          INPUT_GOARM: ${{ inputs.goarm }}
         run: |
           set -euo pipefail
+
+          # Only set GOARM when building for ARM architecture
+          if [[ "${GOARCH}" == "arm" ]]; then
+            if [[ -z "${INPUT_GOARM}" ]]; then
+              echo "::error::GOARM is required when GOARCH=arm"
+              exit 1
+            fi
+            export GOARM="${INPUT_GOARM}"
+          fi
+
           go build -trimpath \
             -ldflags="${LDFLAGS}" \
             -o "${BINARY_NAME}" \
@@ -93,7 +115,7 @@ jobs:
       - name: Upload binary to release
         if: inputs.upload-to-release && inputs.release-tag != ''
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ inputs.release-tag }}
           BINARY: ${{ inputs.binary-name }}
         run: |

--- a/.github/workflows/build-go-attest.yml
+++ b/.github/workflows/build-go-attest.yml
@@ -102,21 +102,29 @@ jobs:
             export GOARM="${INPUT_GOARM}"
           fi
 
+          # Append .exe for Windows targets
+          OUTPUT="${BINARY_NAME}"
+          if [[ "${GOOS}" == "windows" ]]; then
+            OUTPUT="${BINARY_NAME}.exe"
+          fi
+
           go build -trimpath \
             -ldflags="${LDFLAGS}" \
-            -o "${BINARY_NAME}" \
+            -o "${OUTPUT}" \
             "${MAIN_PACKAGE}"
+
+          # Export actual filename for subsequent steps
+          echo "BINARY=${OUTPUT}" >> "$GITHUB_ENV"
 
       - name: Generate provenance attestation
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
-          subject-path: ${{ inputs.binary-name }}
+          subject-path: ${{ env.BINARY }}
 
       - name: Upload binary to release
         if: inputs.upload-to-release && inputs.release-tag != ''
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ inputs.release-tag }}
-          BINARY: ${{ inputs.binary-name }}
         run: |
           gh release upload "$RELEASE_TAG" "$BINARY" --clobber

--- a/.github/workflows/build-go-attest.yml
+++ b/.github/workflows/build-go-attest.yml
@@ -1,0 +1,100 @@
+name: Build Go Binary with Provenance Attestation
+
+on:
+  workflow_call:
+    inputs:
+      binary-name:
+        description: "Output binary name (e.g., myapp-linux-amd64)"
+        required: true
+        type: string
+      goos:
+        description: "Target OS (GOOS)"
+        required: true
+        type: string
+      goarch:
+        description: "Target architecture (GOARCH)"
+        required: true
+        type: string
+      goarm:
+        description: "ARM version (GOARM) - only for goarch=arm"
+        required: false
+        type: string
+        default: ""
+      go-version-file:
+        description: "Path to go.mod or .go-version for Go version detection"
+        required: false
+        type: string
+        default: "go.mod"
+      main-package:
+        description: "Go main package path"
+        required: false
+        type: string
+        default: "."
+      ldflags:
+        description: "Linker flags (-ldflags value)"
+        required: false
+        type: string
+        default: "-s -w"
+      release-tag:
+        description: "Release tag for uploading the binary as a release asset"
+        required: false
+        type: string
+        default: ""
+      upload-to-release:
+        description: "Upload binary to GitHub release (requires release-tag)"
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+jobs:
+  build:
+    name: Build and Attest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout caller repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: ${{ inputs.go-version-file }}
+
+      - name: Build binary
+        env:
+          CGO_ENABLED: "0"
+          GOOS: ${{ inputs.goos }}
+          GOARCH: ${{ inputs.goarch }}
+          GOARM: ${{ inputs.goarm }}
+          BINARY_NAME: ${{ inputs.binary-name }}
+          LDFLAGS: ${{ inputs.ldflags }}
+          MAIN_PACKAGE: ${{ inputs.main-package }}
+        run: |
+          set -euo pipefail
+          go build -trimpath \
+            -ldflags="${LDFLAGS}" \
+            -o "${BINARY_NAME}" \
+            "${MAIN_PACKAGE}"
+
+      - name: Generate provenance attestation
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: ${{ inputs.binary-name }}
+
+      - name: Upload binary to release
+        if: inputs.upload-to-release && inputs.release-tag != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.release-tag }}
+          BINARY: ${{ inputs.binary-name }}
+        run: |
+          gh release upload "$RELEASE_TAG" "$BINARY" --clobber

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint-workflows:
+    name: Lint Workflows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: actionlint
+        uses: reviewdog/action-actionlint@0d952c597ef8459f634d7145b0b044a9699e5e43 # v1.71.0
+        with:
+          fail_level: error


### PR DESCRIPTION
## Summary

Adds a reusable workflow for building Go binaries with SLSA Level 3 provenance attestation.

## Why

`slsa-framework/slsa-github-generator` [cannot be SHA-pinned](https://github.com/slsa-framework/slsa-github-generator/issues/4440), breaking repos that enforce SHA-pinning rules. This workflow replaces it with `actions/attest-build-provenance` (v4.1.0) which is fully SHA-pinnable.

Hosting the build workflow in the org `.github` repo provides true SLSA L3 isolation — callers cannot modify the build process.

## Interface

```yaml
uses: netresearch/.github/.github/workflows/build-go-attest.yml@main
with:
  binary-name: myapp-linux-amd64
  goos: linux
  goarch: amd64
  ldflags: "-s -w -X main.version=v1.0.0"
  release-tag: v1.0.0
```

### Inputs

| Input | Required | Default | Description |
|-------|----------|---------|-------------|
| `binary-name` | yes | - | Output binary name |
| `goos` | yes | - | Target OS |
| `goarch` | yes | - | Target architecture |
| `goarm` | no | "" | ARM version (for goarch=arm) |
| `go-version-file` | no | "go.mod" | Go version detection file |
| `main-package` | no | "." | Main package path |
| `ldflags` | no | "-s -w" | Linker flags |
| `release-tag` | no | "" | Release tag for asset upload |
| `upload-to-release` | no | true | Upload binary to release |

## First consumer

`netresearch/ofelia` will be the first consumer (PR pending).