### PR TITLE
chore: update actions and force Node.js 24 for node20 actions

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/build-go-attest.yml
+++ b/.github/workflows/build-go-attest.yml
@@ -67,7 +67,7 @@ jobs:
       attestations: write
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: audit
 
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: audit
 
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
       actions: read
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -21,7 +21,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: audit
 
@@ -32,6 +32,8 @@ jobs:
 
       - name: Dependency Review
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
           fail-on-severity: ${{ inputs.fail-on-severity || 'high' }}
           comment-summary-in-pr: always

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -29,7 +29,7 @@ jobs:
       security-events: write
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: audit
 
@@ -42,5 +42,6 @@ jobs:
       - name: Run Gitleaks
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -30,7 +30,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -21,7 +21,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -41,7 +41,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/node-audit.yml
+++ b/.github/workflows/node-audit.yml
@@ -35,7 +35,7 @@ jobs:
       contents: read
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -65,7 +65,7 @@ jobs:
             if (total > warning) size = 'large';
             else if (total > Math.floor(warning / 2.5)) size = 'medium';
 
-            console.log(`PR Size: ${size} (${additions}+ / ${deletions}-)`); 
+            console.log(`PR Size: ${size} (${additions}+ / ${deletions}-)`);
 
             if (total > alert) {
               core.warning(`Large PR with ${total} changes. Consider breaking into smaller PRs.`);

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -32,7 +32,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: audit
 
@@ -82,7 +82,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -17,7 +17,7 @@ jobs:
       actions: read
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -71,7 +71,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
           egress-policy: audit
 

--- a/docs/supply-chain-security.md
+++ b/docs/supply-chain-security.md
@@ -3,7 +3,7 @@
 ## Defense Layers
 
 | Layer | Mechanism | Scope | When |
-|-------|-----------|-------|------|
+| ----- | --------- | ----- | ---- |
 | 1. Stability delay | Renovate `stabilityDays: 3` | All repos with Renovate | Before PR creation |
 | 2. Dependency review | `dependency-review-action` | All repos (org-wide default) | On every PR |
 | 3. Package audit | `pnpm audit` / `composer audit` | Repos with audit workflow | On every PR |

--- a/docs/supply-chain-security.md
+++ b/docs/supply-chain-security.md
@@ -35,14 +35,14 @@ When a supply chain attack is discovered:
 
 ### Short-term (within 24 hours)
 
-3. **Revert affected repos** — downgrade to last safe version, regenerate lockfiles
-4. **Rotate secrets** — if the malicious package could have exfiltrated credentials
-5. **Audit CI logs** — check if the malicious code ran in any CI pipeline
+1. **Revert affected repos** — downgrade to last safe version, regenerate lockfiles
+2. **Rotate secrets** — if the malicious package could have exfiltrated credentials
+3. **Audit CI logs** — check if the malicious code ran in any CI pipeline
 
 ### Post-incident
 
-6. **Review auto-merge logs** — identify if/how the compromised version was merged
-7. **Update this document** with lessons learned
+1. **Review auto-merge logs** — identify if/how the compromised version was merged
+2. **Update this document** with lessons learned
 
 ## Workflow Architecture
 
@@ -79,7 +79,7 @@ netresearch/renovate-config
 ## Key Repos
 
 | Repo | Role |
-|------|------|
+| ---- | ---- |
 | [`netresearch/renovate-config`](https://github.com/netresearch/renovate-config) | Org-wide Renovate preset (deny-lists, stability delay) |
 | [`netresearch/.github`](https://github.com/netresearch/.github) | Org-wide default workflows + generic reusable workflows |
 | [`netresearch/typo3-ci-workflows`](https://github.com/netresearch/typo3-ci-workflows) | TYPO3/PHP-specific reusable workflows |


### PR DESCRIPTION
## Summary
- Update `step-security/harden-runner` v2.16.0 → v2.16.1 across all 13 workflow files
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` env to `gitleaks-action` and `dependency-review-action` steps — both actions still ship `node20` with no newer release available
- GitHub will force Node.js 24 on 2026-06-02; this opts in early to avoid breakage

Closes #3

## Test plan
- [ ] CI passes on this repo
- [ ] Consumer repos (e.g. t3x-rte_ckeditor_image) no longer show Node.js 20 deprecation warnings after merge