### PR TITLE
fix(ci): update actions/setup-node to v6.3.0 in node-audit

### DIFF
--- a/.github/workflows/node-audit.yml
+++ b/.github/workflows/node-audit.yml
@@ -51,7 +51,7 @@ jobs:
           version: ${{ inputs.pnpm-version }}
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: ${{ inputs.node-version-file }}
 


### PR DESCRIPTION
## Summary
- Updates `actions/setup-node` from v4 (`49933ea`) to v6.3.0 (`53b83947`) in the reusable `node-audit.yml` workflow
- Resolves GitHub deprecation warning: Node.js 20 actions will be forced to Node 24 starting June 2, 2026

## Test plan
- [ ] Verify node-audit jobs in consuming repos no longer emit the Node.js 20 deprecation annotation