### PR TITLE
fix(ci): enable corepack for Yarn 4+ in node-audit

### DIFF
--- a/.github/workflows/node-audit.yml
+++ b/.github/workflows/node-audit.yml
@@ -50,6 +50,10 @@ jobs:
         with:
           version: ${{ inputs.pnpm-version }}
 
+      - name: Enable Corepack
+        if: inputs.package-manager == 'yarn'
+        run: corepack enable
+
       - name: Setup Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:


### PR DESCRIPTION
## Summary
- Adds `corepack enable` step before `setup-node` when `package-manager: yarn` is configured
- Without this, projects using `packageManager: "yarn@4.x"` in package.json fail because the runner only has Yarn Classic 1.22 globally

## Test plan
- [ ] Verify `node-audit` job passes for repos using Yarn 4 (e.g. postdirekt-autocomplete-monorepo)