### PR TITLE
fix(ci): skip auto-approve for external/fork PRs

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -76,8 +76,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: quality-gate
-    # Skip (not fail) for external/fork PRs — auto-approve only applies to
-    # same-repo branches created by the project maintainer.
+    # Skip (not fail) for fork PRs — auto-approve only applies to same-repo
+    # branches. Fork PRs always fail because GITHUB_TOKEN lacks permission.
     if: >-
       github.event.pull_request.draft == false
       && github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -76,7 +76,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: quality-gate
-    if: github.event.pull_request.draft == false
+    # Skip (not fail) for external/fork PRs — auto-approve only applies to
+    # same-repo branches created by the project maintainer.
+    if: >-
+      github.event.pull_request.draft == false
+      && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary

- Auto-Approve job now **skips** (not fails) for external/fork PRs
- Adds `head.repo.full_name == github.repository` guard so the job only runs for same-repo branches created by the project maintainer
- The `GITHUB_TOKEN` cannot approve fork PRs anyway, so this was always failing for external contributions (e.g. [netresearch/go-cron#358](https://github.com/netresearch/go-cron/pull/358))

## Test plan

- [ ] Open a PR from a fork on a repo using this shared workflow — Auto-Approve should show as **skipped**
- [ ] Open a same-repo PR — Auto-Approve should still run and approve as before