### PR TITLE
feat(ci): add Cosign signing and GitHub attestation to golib release

### DIFF
--- a/.github/workflows/golib-create-release.yml
+++ b/.github/workflows/golib-create-release.yml
@@ -158,16 +158,11 @@ jobs:
           output-file: sbom-${{ steps.tag.outputs.version }}.spdx.json
 
       - name: Generate checksums
-        env:
-          VERSION: ${{ steps.tag.outputs.version }}
         run: |
-          # Checksum all release artifacts that exist
-          FILES=""
-          for f in sbom-*.json; do
-            [ -f "$f" ] && FILES="$FILES $f"
-          done
-          if [ -n "$FILES" ]; then
-            sha256sum $FILES > checksums.txt
+          shopt -s nullglob
+          files=(sbom-*.json)
+          if [ ${#files[@]} -gt 0 ]; then
+            sha256sum "${files[@]}" > checksums.txt
             cat checksums.txt
           else
             echo "No artifacts to checksum"
@@ -199,12 +194,18 @@ jobs:
             checksums.txt
 
       - name: Generate attestation for release artifacts
-        if: inputs.attest
-        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
+        if: inputs.attest && inputs.generate-sbom
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: |
             sbom-*.json
             checksums.txt
+
+      - name: Generate attestation (checksums only)
+        if: inputs.attest && !inputs.generate-sbom
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: checksums.txt
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
@@ -213,6 +214,7 @@ jobs:
           draft: ${{ inputs.draft }}
           prerelease: ${{ contains(steps.tag.outputs.tag, '-rc') || contains(steps.tag.outputs.tag, '-alpha') || contains(steps.tag.outputs.tag, '-beta') }}
           body: ${{ steps.notes.outputs.notes }}
+          fail_on_unmatched_files: false
           files: |
             sbom-*.json
             checksums.txt

--- a/.github/workflows/golib-create-release.yml
+++ b/.github/workflows/golib-create-release.yml
@@ -14,7 +14,17 @@ on:
         type: boolean
         default: true
       generate-sbom:
-        description: "Generate SPDX SBOM for the source tree"
+        description: "Generate SBOM artifacts"
+        required: false
+        type: boolean
+        default: true
+      cosign-sign:
+        description: "Sign checksums with Cosign (keyless / Sigstore)"
+        required: false
+        type: boolean
+        default: true
+      attest:
+        description: "Generate GitHub artifact attestation for release assets"
         required: false
         type: boolean
         default: true
@@ -22,8 +32,35 @@ on:
 permissions: {}
 
 jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: go test -race -v ./...
+
   release:
     name: Create Release
+    needs: test
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -97,6 +134,20 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Set up Go
+        if: inputs.generate-sbom
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Generate SBOM (CycloneDX)
+        if: inputs.generate-sbom
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: .
+          format: cyclonedx-json
+          output-file: sbom-${{ steps.tag.outputs.version }}.cyclonedx.json
+
       - name: Generate SBOM (SPDX)
         if: inputs.generate-sbom
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
@@ -106,11 +157,51 @@ jobs:
           output-file: sbom-${{ steps.tag.outputs.version }}.spdx.json
 
       - name: Generate checksums
-        if: inputs.generate-sbom
         env:
           VERSION: ${{ steps.tag.outputs.version }}
         run: |
-          sha256sum "sbom-${VERSION}.spdx.json" > checksums.txt
+          # Checksum all release artifacts that exist
+          FILES=""
+          for f in sbom-*.json; do
+            [ -f "$f" ] && FILES="$FILES $f"
+          done
+          if [ -n "$FILES" ]; then
+            sha256sum $FILES > checksums.txt
+            cat checksums.txt
+          else
+            echo "No artifacts to checksum"
+            touch checksums.txt
+          fi
+
+      - name: Install Cosign
+        if: inputs.cosign-sign
+        uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
+
+      - name: Sign checksums with Cosign (keyless)
+        if: inputs.cosign-sign
+        run: |
+          cosign sign-blob --yes \
+            --output-certificate checksums.txt.pem \
+            --output-signature checksums.txt.sig \
+            checksums.txt
+
+      - name: Verify Cosign signature
+        if: inputs.cosign-sign
+        run: |
+          cosign verify-blob \
+            --certificate checksums.txt.pem \
+            --signature checksums.txt.sig \
+            --certificate-identity-regexp "https://github.com/${{ github.repository }}/*" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            checksums.txt
+
+      - name: Generate attestation for release artifacts
+        if: inputs.attest
+        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
+        with:
+          subject-path: |
+            sbom-*.json
+            checksums.txt
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
@@ -120,7 +211,9 @@ jobs:
           prerelease: ${{ contains(steps.tag.outputs.tag, '-rc') || contains(steps.tag.outputs.tag, '-alpha') || contains(steps.tag.outputs.tag, '-beta') }}
           body: ${{ steps.notes.outputs.notes }}
           files: |
-            sbom-*.spdx.json
+            sbom-*.json
             checksums.txt
+            checksums.txt.sig
+            checksums.txt.pem
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/golib-create-release.yml
+++ b/.github/workflows/golib-create-release.yml
@@ -112,6 +112,7 @@ jobs:
         id: notes
         env:
           TAG: ${{ steps.tag.outputs.tag }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           DELIMITER="ghadelim_$(openssl rand -hex 8)"
@@ -129,7 +130,7 @@ jobs:
               git log --pretty=format:"- %s" "${PREVIOUS_TAG}..${TAG}"
               echo ""
               echo ""
-              echo "**Full changelog**: https://github.com/${{ github.repository }}/compare/${PREVIOUS_TAG}...${TAG}"
+              echo "**Full changelog**: https://github.com/${REPO}/compare/${PREVIOUS_TAG}...${TAG}"
               echo "$DELIMITER"
             } >> "$GITHUB_OUTPUT"
           fi
@@ -187,11 +188,13 @@ jobs:
 
       - name: Verify Cosign signature
         if: inputs.cosign-sign
+        env:
+          REPO: ${{ github.repository }}
         run: |
           cosign verify-blob \
             --certificate checksums.txt.pem \
             --signature checksums.txt.sig \
-            --certificate-identity-regexp "https://github.com/${{ github.repository }}/*" \
+            --certificate-identity-regexp "https://github.com/${REPO}/*" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
             checksums.txt
 


### PR DESCRIPTION
## Summary

Enhances `golib-create-release.yml` to be a complete release workflow for Go libraries, replacing the need for per-repo release + SLSA provenance workflows.

- Add pre-release test job (run tests before creating release)
- Add CycloneDX SBOM generation (alongside existing SPDX)
- Add Cosign keyless signing of checksums (opt-in via `cosign-sign` input)
- Add GitHub-native `actions/attest-build-provenance` (opt-in via `attest` input)
- All new capabilities default to enabled but are opt-out

This replaces `slsa-framework/slsa-github-generator` which is blocked by SHA-pinning rulesets in consumer repos (e.g., [go-cron#24511557622](https://github.com/netresearch/go-cron/actions/runs/24511557622/job/71643851200)).

## Test plan

- [ ] Migrate go-cron to use this workflow (follow-up PR)
- [ ] Verify release creates SBOMs, checksums, Cosign signatures, and attestations