### PR TITLE
fix(build-container): gate semver tags to tag builds only

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -91,9 +91,9 @@ jobs:
           tags: |
             type=ref,event=branch,enable=${{ !inputs.ref }}
             type=ref,event=pr,enable=${{ !inputs.ref }}
-            type=semver,pattern={{version}},value=${{ env.SEMVER_REF }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ env.SEMVER_REF }}
-            type=semver,pattern={{major}},value=${{ env.SEMVER_REF }}
+            type=semver,pattern={{version}},value=${{ env.SEMVER_REF }},enable=${{ inputs.ref != '' || startsWith(github.ref, 'refs/tags/') }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ env.SEMVER_REF }},enable=${{ inputs.ref != '' || startsWith(github.ref, 'refs/tags/') }}
+            type=semver,pattern={{major}},value=${{ env.SEMVER_REF }},enable=${{ inputs.ref != '' || startsWith(github.ref, 'refs/tags/') }}
 
       - name: Log in to ${{ inputs.registry }}
         if: inputs.push


### PR DESCRIPTION
## Summary

Follow-up to #20. Adds an `enable` guard to the three `type=semver` tag rules so semver parsing only runs when we actually have a semver ref to parse — i.e. on tag pushes or when the caller provides `inputs.ref` (workflow_dispatch backfills).

## Why

On PR and branch builds, `github.ref_name` is something like `532/merge` or `main`, not a semver. metadata-action still tries to parse it and emits **warning annotations** like:

> 532-merge is not a valid semver

— three per run (one per semver pattern). Not functional, just noise. This gates the semver rules to contexts where semver actually applies.

## Test plan

- [ ] PR build produces no "not a valid semver" warning annotations.
- [ ] Tag push still produces `{version}`, `{major}.{minor}`, `{major}` tags.
- [ ] workflow_dispatch with `ref: v1.3.0` still produces the same semver tags.