### PR TITLE
feat(workflows): add reusable create-release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,234 @@
+name: Create GitHub Release
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: "Release tag (e.g. v1.3.0). Defaults to github.ref_name."
+        required: false
+        type: string
+        default: ""
+      require-annotated-tag:
+        description: "Reject lightweight tags (require annotated or signed)."
+        required: false
+        type: boolean
+        default: true
+      prerelease:
+        description: "Prerelease override: 'auto' (detect -rc/-alpha/-beta/-pre suffix), 'true', or 'false'."
+        required: false
+        type: string
+        default: "auto"
+      make-latest:
+        description: "make_latest override: 'auto' (compute from semver vs existing releases), 'true', or 'false'."
+        required: false
+        type: string
+        default: "auto"
+      previous-tag:
+        description: "Override previous tag used for changelog generation."
+        required: false
+        type: string
+        default: ""
+      draft:
+        description: "Create as draft. Defaults to false (auto-publish)."
+        required: false
+        type: boolean
+        default: false
+    outputs:
+      tag:
+        description: "Resolved tag name (e.g. v1.3.0)."
+        value: ${{ jobs.release.outputs.tag }}
+      version:
+        description: "Version without leading v (e.g. 1.3.0)."
+        value: ${{ jobs.release.outputs.version }}
+      release-url:
+        description: "URL of the created/updated release."
+        value: ${{ jobs.release.outputs.release-url }}
+      upload-url:
+        description: "Upload URL for release assets."
+        value: ${{ jobs.release.outputs.upload-url }}
+      is-latest:
+        description: "Whether this release was marked as latest (true/false)."
+        value: ${{ jobs.release.outputs.is-latest }}
+      is-prerelease:
+        description: "Whether this release was marked as prerelease (true/false)."
+        value: ${{ jobs.release.outputs.is-prerelease }}
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      version: ${{ steps.tag.outputs.version }}
+      release-url: ${{ steps.create.outputs.release-url }}
+      upload-url: ${{ steps.create.outputs.upload-url }}
+      is-latest: ${{ steps.flags.outputs.make_latest }}
+      is-prerelease: ${{ steps.flags.outputs.is_prerelease }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Resolve tag
+        id: tag
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          TAG="${INPUT_TAG:-$REF_NAME}"
+          case "$TAG" in
+            v[0-9]*) ;;
+            *) echo "::error::Tag '$TAG' does not match vX.Y.Z pattern"; exit 1 ;;
+          esac
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify annotated tag
+        if: inputs.require-annotated-tag
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          TAG_TYPE=$(git cat-file -t "$TAG")
+          if [ "$TAG_TYPE" != "tag" ]; then
+            echo "::error::Tag $TAG is lightweight (type: $TAG_TYPE). Only annotated/signed tags are allowed."
+            exit 1
+          fi
+          echo "Tag $TAG is annotated (type: $TAG_TYPE)"
+          if git tag -v "$TAG" 2>/dev/null; then
+            echo "Tag signature verified"
+          else
+            echo "::warning::Tag $TAG signature not verifiable (signing key not available in CI — informational only)"
+          fi
+
+      - name: Compute prerelease and make_latest flags
+        id: flags
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          REPO: ${{ github.repository }}
+          PRERELEASE_INPUT: ${{ inputs.prerelease }}
+          MAKE_LATEST_INPUT: ${{ inputs.make-latest }}
+        run: |
+          set -euo pipefail
+
+          case "$PRERELEASE_INPUT" in
+            true|false)
+              IS_PRE="$PRERELEASE_INPUT"
+              ;;
+            auto)
+              case "$TAG" in
+                *-rc*|*-alpha*|*-beta*|*-pre*) IS_PRE=true ;;
+                *) IS_PRE=false ;;
+              esac
+              ;;
+            *)
+              echo "::error::invalid prerelease input '$PRERELEASE_INPUT' (expected: auto|true|false)"; exit 1 ;;
+          esac
+          echo "is_prerelease=$IS_PRE" >> "$GITHUB_OUTPUT"
+
+          case "$MAKE_LATEST_INPUT" in
+            true|false)
+              MAKE_LATEST="$MAKE_LATEST_INPUT"
+              ;;
+            auto)
+              if [ "$IS_PRE" = "true" ]; then
+                MAKE_LATEST=false
+              else
+                EXISTING=$(gh api "repos/$REPO/releases" --paginate --jq '.[] | select(.draft==false and .prerelease==false) | .tag_name' || true)
+                if [ -z "$EXISTING" ]; then
+                  MAKE_LATEST=true
+                else
+                  HIGHEST=$(printf '%s\n%s\n' "$TAG" "$EXISTING" | grep -v '^$' | sort -V -r | head -n1)
+                  if [ "$HIGHEST" = "$TAG" ]; then
+                    MAKE_LATEST=true
+                  else
+                    MAKE_LATEST=false
+                    echo "::notice::Tag $TAG is not the highest semver (highest: $HIGHEST) — not marking as latest."
+                  fi
+                fi
+              fi
+              ;;
+            *)
+              echo "::error::invalid make-latest input '$MAKE_LATEST_INPUT' (expected: auto|true|false)"; exit 1 ;;
+          esac
+          echo "make_latest=$MAKE_LATEST" >> "$GITHUB_OUTPUT"
+          echo "Resolved: prerelease=$IS_PRE, make_latest=$MAKE_LATEST"
+
+      - name: Generate release notes
+        id: notes
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          PREVIOUS_OVERRIDE: ${{ inputs.previous-tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          DELIMITER="ghadelim_$(openssl rand -hex 8)"
+
+          if [ -n "$PREVIOUS_OVERRIDE" ]; then
+            PREVIOUS_TAG="$PREVIOUS_OVERRIDE"
+          else
+            PREVIOUS_TAG=$(git tag --list 'v[0-9]*' --sort=-v:refname | grep -v "^${TAG}$" | head -n1 || true)
+          fi
+
+          {
+            echo "notes<<$DELIMITER"
+            if [ -z "$PREVIOUS_TAG" ]; then
+              echo "Initial release."
+            else
+              git log --pretty=format:"- %s" "$PREVIOUS_TAG..$TAG"
+              echo ""
+              echo ""
+              echo "**Full changelog**: https://github.com/$REPO/compare/$PREVIOUS_TAG...$TAG"
+            fi
+            echo "$DELIMITER"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create or update GitHub Release
+        id: create
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          NOTES: ${{ steps.notes.outputs.notes }}
+          MAKE_LATEST: ${{ steps.flags.outputs.make_latest }}
+          IS_PRE: ${{ steps.flags.outputs.is_prerelease }}
+          DRAFT: ${{ inputs.draft }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+            echo "Release $TAG already exists — updating"
+            gh release edit "$TAG" --repo "$REPO" --notes "$NOTES" --latest="$MAKE_LATEST" --prerelease="$IS_PRE" --draft="$DRAFT"
+          else
+            echo "Creating new release $TAG"
+            CREATE_ARGS=("$TAG" "--repo" "$REPO" "--title" "$TAG" "--notes" "$NOTES" "--latest=$MAKE_LATEST")
+            if [ "$IS_PRE" = "true" ]; then
+              CREATE_ARGS+=("--prerelease")
+            fi
+            if [ "$DRAFT" = "true" ]; then
+              CREATE_ARGS+=("--draft")
+            fi
+            gh release create "${CREATE_ARGS[@]}"
+          fi
+
+          URL=$(gh release view "$TAG" --repo "$REPO" --json url --jq .url)
+          UPLOAD=$(gh api "repos/$REPO/releases/tags/$TAG" --jq .upload_url)
+          echo "release-url=$URL" >> "$GITHUB_OUTPUT"
+          echo "upload-url=$UPLOAD" >> "$GITHUB_OUTPUT"
+          echo "Release: $URL"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -91,10 +91,13 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${INPUT_TAG:-$REF_NAME}"
-          case "$TAG" in
-            v[0-9]*) ;;
-            *) echo "::error::Tag '$TAG' does not match vX.Y.Z pattern"; exit 1 ;;
-          esac
+          # Strict semver check: v<major>.<minor>.<patch> with optional
+          # -prerelease / +build suffixes (SemVer 2.0.0).
+          SEMVER_RE='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+          if ! [[ "$TAG" =~ $SEMVER_RE ]]; then
+            echo "::error::Tag '$TAG' is not a valid vMAJOR.MINOR.PATCH semver (e.g. v1.2.3, v1.2.3-rc1)"
+            exit 1
+          fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
@@ -150,7 +153,15 @@ jobs:
               if [ "$IS_PRE" = "true" ]; then
                 MAKE_LATEST=false
               else
-                EXISTING=$(gh api "repos/$REPO/releases" --paginate --jq '.[] | select(.draft==false and .prerelease==false) | .tag_name' || true)
+                # Fail hard on API error — silently defaulting to
+                # "no existing releases" could incorrectly stamp an old
+                # tag as latest.
+                ALL_TAGS=$(gh api "repos/$REPO/releases" --paginate --jq '.[] | select(.draft==false and .prerelease==false) | .tag_name')
+                # Filter to semver-shaped tags only; ignore non-semver
+                # release tags (e.g. "nightly", "prod") which would
+                # confuse version comparison.
+                SEMVER_RE_GREP='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+                EXISTING=$(printf '%s\n' "$ALL_TAGS" | grep -E "$SEMVER_RE_GREP" || true)
                 if [ -z "$EXISTING" ]; then
                   MAKE_LATEST=true
                 else


### PR DESCRIPTION
## Summary

New reusable workflow for **application repos** to create GitHub Releases from tag pushes. Complements the existing `golib-create-release.yml` which is library-specific (bundles tests + library SBOM). This one is minimal: verify tag → generate notes → create release object. Asset uploads are delegated to other reusables (`build-go-attest`, `build-container`, `finalize-release`).

## Key feature: computed `make_latest`

Compares the new tag to all existing non-draft non-prerelease releases via `sort -V` (semver sort). Marks as latest **only** when the new tag is the highest. Prevents the scenario that just bit us on `ldap-manager#v1.2.0`:

- Backfilling an old tag → not latest ✅
- Bugfix release for a previous major (e.g. v11.5.8 when v13.0.0 exists) → not latest ✅
- Actual new version → latest ✅
- Prerelease (auto-detected from `-rc/-alpha/-beta/-pre` suffix) → not latest ✅

Override via `make-latest: true|false|auto` input.

## Inputs

| Name | Default | Description |
|---|---|---|
| `tag` | `""` | Tag to release; defaults to `github.ref_name` |
| `require-annotated-tag` | `true` | Reject lightweight tags |
| `prerelease` | `auto` | `auto` / `true` / `false` |
| `make-latest` | `auto` | `auto` (semver compare) / `true` / `false` |
| `previous-tag` | `""` | Override previous tag for changelog |
| `draft` | `false` | Create as draft |

## Outputs

`tag`, `version`, `release-url`, `upload-url`, `is-latest`, `is-prerelease` — consumed by downstream reusables.

## Idempotent

Re-running on the same tag **updates** the existing release (edits notes, flips flags) rather than failing. Useful for fix-forward after transient CI failures.

## Example caller

```yaml
on:
  push:
    tags: ["v*"]

jobs:
  release:
    uses: netresearch/.github/.github/workflows/create-release.yml@main
    permissions:
      contents: write
  # downstream jobs can use needs.release.outputs.upload-url
```

## Test plan

- [ ] actionlint passes
- [ ] yamllint passes
- [ ] Sort logic verified: new higher semver → latest; older bugfix tag → not latest; prerelease → not latest