### PR TITLE
feat(build-container): add cosign signing and SLSA provenance

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -47,11 +47,33 @@ on:
         required: false
         type: boolean
         default: true
+      sign:
+        description: "Cosign keyless OIDC sign the pushed image by digest. Requires push=true."
+        required: false
+        type: boolean
+        default: false
+      attest:
+        description: "Generate SLSA build provenance attestation for the pushed image (actions/attest-build-provenance). Requires push=true."
+        required: false
+        type: boolean
+        default: false
+    outputs:
+      digest:
+        description: "Digest of the pushed image (sha256:...)."
+        value: ${{ jobs.build.outputs.digest }}
+      image-ref:
+        description: "Full image reference <registry>/<owner>/<image-name>."
+        value: ${{ jobs.build.outputs.image-ref }}
+      tags:
+        description: "Newline-separated list of pushed tags (from docker/metadata-action)."
+        value: ${{ jobs.build.outputs.tags }}
 
 permissions:
   contents: read
   packages: write
   security-events: write
+  id-token: write
+  attestations: write
 
 jobs:
   build:
@@ -61,6 +83,12 @@ jobs:
       contents: read
       packages: write
       security-events: write
+      id-token: write
+      attestations: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+      image-ref: ${{ env.IMAGE_REF }}
+      tags: ${{ steps.meta.outputs.tags }}
     env:
       IMAGE_REF: ${{ inputs.registry }}/${{ github.repository_owner }}/${{ inputs.image-name }}
     steps:
@@ -136,3 +164,24 @@ jobs:
         with:
           sarif_file: "trivy-results.sarif"
           category: "container-scan"
+
+      - name: Install Cosign
+        if: inputs.sign && inputs.push
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+      - name: Sign image with Cosign (keyless OIDC)
+        if: inputs.sign && inputs.push
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          # Sign by digest to cover all tags pointing at this image (recommended practice).
+          cosign sign --yes "${IMAGE_REF}@${DIGEST}"
+
+      - name: Generate SLSA build provenance attestation
+        if: inputs.attest && inputs.push
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ${{ env.IMAGE_REF }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -59,15 +59,19 @@ on:
         default: false
     outputs:
       digest:
-        description: "Digest of the pushed image (sha256:...)."
+        description: "Digest of the pushed image (sha256:...). Empty when push=false."
         value: ${{ jobs.build.outputs.digest }}
-      image-ref:
+      image_ref:
         description: "Full image reference <registry>/<owner>/<image-name>."
-        value: ${{ jobs.build.outputs.image-ref }}
+        value: ${{ jobs.build.outputs.image_ref }}
       tags:
-        description: "Newline-separated list of pushed tags (from docker/metadata-action)."
+        description: "Newline-separated list of pushed tags (from docker/metadata-action). Empty when push=false."
         value: ${{ jobs.build.outputs.tags }}
 
+# Note on permissions: the reusable workflow declares the maximum set it
+# *may* use. GitHub clamps to the caller's granted permissions, so
+# callers that enable `sign: true` or `attest: true` MUST also grant
+# `id-token: write` and `attestations: write` at their job level.
 permissions:
   contents: read
   packages: write
@@ -87,7 +91,7 @@ jobs:
       attestations: write
     outputs:
       digest: ${{ steps.build.outputs.digest }}
-      image-ref: ${{ env.IMAGE_REF }}
+      image_ref: ${{ env.IMAGE_REF }}
       tags: ${{ steps.meta.outputs.tags }}
     env:
       IMAGE_REF: ${{ inputs.registry }}/${{ github.repository_owner }}/${{ inputs.image-name }}


### PR DESCRIPTION
## Summary

Adds two optional capabilities to `build-container.yml`, both **off by default** for backwards compatibility:

- **`sign: true`** — cosign keyless OIDC signs the pushed image by digest. All tags pointing at the digest inherit the signature. Verified via the Sigstore public transparency log.
- **`attest: true`** — generates a SLSA build provenance attestation via `actions/attest-build-provenance` and pushes it to the registry as an OCI referrer. Verifiable with `gh attestation verify oci://<image>@<digest>`.

Both require `push: true`.

## Permissions

Workflow-level permissions upgraded with `id-token: write` and `attestations: write` (needed for keyless signing / attestation generation). Callers that don't enable the new flags are unaffected.

## New outputs

| Output | Description |
|---|---|
| `digest` | Pushed image digest (`sha256:...`) |
| `image-ref` | Full image reference (`<registry>/<owner>/<image-name>`) |
| `tags` | Newline-separated list of pushed tags |

Downstream `finalize-release.yml` will consume these to include verification instructions in release notes.

## Backwards compatibility

The sole current caller (`netresearch/ldap-selfservice-password-changer/.github/workflows/docker.yml`) does not set `sign` or `attest`, so it will keep building exactly as today. Org rollout to all repos enables them explicitly.

## Test plan

- [ ] actionlint passes
- [ ] Existing caller (`ldap-selfservice-password-changer`) still builds cleanly on next run
- [ ] Opting in (e.g. `sign: true, attest: true`) produces: pushed image + cosign signature in Rekor + SLSA provenance attestation queryable via `gh attestation verify`