### PR TITLE
feat(build-go-attest): add pre-build hook + bun/node setup + ref input

### DIFF
--- a/.github/workflows/build-go-attest.yml
+++ b/.github/workflows/build-go-attest.yml
@@ -80,6 +80,11 @@ on:
         required: false
         type: string
         default: "lts/*"
+      bun-version:
+        description: "Bun version (when setup-bun=true). Pin to a specific version for reproducible builds."
+        required: false
+        type: string
+        default: "latest"
       pre-build-command:
         description: "Shell command(s) run after checkout/toolchain setup and before `go build`. Useful for generating embedded assets (bun run build:assets, templ generate, sqlc generate, etc.)."
         required: false
@@ -127,7 +132,7 @@ jobs:
         if: inputs.setup-bun
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
         with:
-          bun-version: latest
+          bun-version: ${{ inputs.bun-version }}
 
       - name: Run pre-build command
         if: inputs.pre-build-command != ''
@@ -136,7 +141,10 @@ jobs:
         run: |
           set -euo pipefail
           echo "::group::pre-build-command"
-          bash -c "$PRE_BUILD_CMD"
+          # Invoke bash with strict flags so pipeline failures and
+          # unset-variable references inside the pre-build command
+          # propagate rather than being silently swallowed.
+          bash -euo pipefail -c "$PRE_BUILD_CMD"
           echo "::endgroup::"
 
       - name: Build binary

--- a/.github/workflows/build-go-attest.yml
+++ b/.github/workflows/build-go-attest.yml
@@ -60,6 +60,31 @@ on:
         required: false
         type: string
         default: "spdx-json"
+      ref:
+        description: "Git ref to check out. Defaults to the caller's github.ref."
+        required: false
+        type: string
+        default: ""
+      setup-bun:
+        description: "Install Bun before running pre-build-command. Set true for projects that embed assets built via Bun (Tailwind, TS bundler, etc.)."
+        required: false
+        type: boolean
+        default: false
+      setup-node:
+        description: "Install Node.js before running pre-build-command."
+        required: false
+        type: boolean
+        default: false
+      node-version:
+        description: "Node.js version (when setup-node=true)."
+        required: false
+        type: string
+        default: "lts/*"
+      pre-build-command:
+        description: "Shell command(s) run after checkout/toolchain setup and before `go build`. Useful for generating embedded assets (bun run build:assets, templ generate, sqlc generate, etc.)."
+        required: false
+        type: string
+        default: ""
 
 # Least privilege: only request write permissions for jobs that need them
 permissions:
@@ -85,11 +110,34 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: ${{ inputs.go-version-file }}
+
+      - name: Set up Node.js
+        if: inputs.setup-node
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Set up Bun
+        if: inputs.setup-bun
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
+        with:
+          bun-version: latest
+
+      - name: Run pre-build command
+        if: inputs.pre-build-command != ''
+        env:
+          PRE_BUILD_CMD: ${{ inputs.pre-build-command }}
+        run: |
+          set -euo pipefail
+          echo "::group::pre-build-command"
+          bash -c "$PRE_BUILD_CMD"
+          echo "::endgroup::"
 
       - name: Build binary
         env:


### PR DESCRIPTION
## Summary

Follow-up to #24. Adds capability for projects that generate embedded assets before \`go build\` (e.g. Tailwind CSS via bun, templ, sqlc). Without this, \`go:embed\` patterns referencing generated files would fail inside the reusable.

## New inputs (all off/empty by default)

| Name | Default | Purpose |
|---|---|---|
| \`ref\` | \`""\` | Git ref to check out. Enables orchestrator-driven backfills. |
| \`setup-bun\` | \`false\` | Install Bun before pre-build-command |
| \`setup-node\` | \`false\` | Install Node.js before pre-build-command |
| \`node-version\` | \`lts/*\` | Node.js version |
| \`pre-build-command\` | \`""\` | Shell run after toolchain setup, before \`go build\` |

## Motivation

\`netresearch/ldap-manager\` and \`netresearch/ldap-selfservice-password-changer\` both run \`bun run build:assets\` to emit CSS that is subsequently embedded via \`go:embed\`. Without a pre-build hook, binary matrix builds via this reusable would miss those assets.

## Test plan

- [ ] actionlint passes
- [ ] Existing callers (simple-ldap-go) unaffected since defaults are no-ops
- [ ] Downstream ldap-manager release workflow consumes these cleanly