### PR TITLE
feat(create-release): expose resolved tag SHA as output

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -52,6 +52,9 @@ on:
       is-prerelease:
         description: "Whether this release was marked as prerelease (true/false)."
         value: ${{ jobs.release.outputs.is-prerelease }}
+      sha:
+        description: "The commit SHA the tag points at. Use this (not github.sha) in downstream ldflags/build-args so workflow_dispatch backfills produce correct provenance."
+        value: ${{ jobs.release.outputs.sha }}
 
 permissions:
   contents: read
@@ -70,6 +73,7 @@ jobs:
       upload-url: ${{ steps.create.outputs.upload-url }}
       is-latest: ${{ steps.flags.outputs.make_latest }}
       is-prerelease: ${{ steps.flags.outputs.is_prerelease }}
+      sha: ${{ steps.tag.outputs.sha }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
@@ -98,8 +102,13 @@ jobs:
             echo "::error::Tag '$TAG' is not a valid vMAJOR.MINOR.PATCH semver (e.g. v1.2.3, v1.2.3-rc1)"
             exit 1
           fi
+          # Resolve the commit SHA the tag points at (unwraps annotated
+          # tags via ^{commit}). Works for workflow_dispatch backfills
+          # where github.sha is the dispatch ref, not the tag's target.
+          SHA=$(git rev-parse "${TAG}^{commit}")
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
 
       - name: Verify annotated tag
         if: inputs.require-annotated-tag

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -106,9 +106,11 @@ jobs:
           # tags via ^{commit}). Works for workflow_dispatch backfills
           # where github.sha is the dispatch ref, not the tag's target.
           SHA=$(git rev-parse "${TAG}^{commit}")
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
-          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          {
+            echo "tag=$TAG"
+            echo "version=${TAG#v}"
+            echo "sha=$SHA"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Verify annotated tag
         if: inputs.require-annotated-tag


### PR DESCRIPTION
Follow-up to #22. Adds a `sha` output to \`create-release.yml\` that resolves the commit SHA the tag points at (unwraps annotated tags via \`^{commit}\`).

## Why

On workflow_dispatch backfills (\`gh workflow run release.yml --ref main -f tag=v1.2.0\`), \`github.sha\` is the dispatch ref SHA (main's HEAD), NOT the tag's target commit. Downstream jobs using \`github.sha\` in ldflags or build-args would bake incorrect provenance into the rebuilt release binaries.

Callers should now use \`needs.create-release.outputs.sha\`.

## Test plan

- [ ] actionlint passes
- [ ] On tag push: sha matches github.sha (unchanged behavior)
- [ ] On workflow_dispatch backfill: sha matches the tag's target commit (not main's HEAD)