### PR TITLE
feat(build-container): add pre-build-command hook

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -57,6 +57,11 @@ on:
         required: false
         type: boolean
         default: false
+      pre-build-command:
+        description: "Shell command(s) run after checkout and before docker build. Useful for downloading release binaries into the build context when the Dockerfile expects pre-built artifacts (e.g. gh release download ...)."
+        required: false
+        type: string
+        default: ""
     outputs:
       digest:
         description: "Digest of the pushed image (sha256:...). Empty when push=false."
@@ -106,6 +111,17 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
           persist-credentials: false
+
+      - name: Run pre-build command
+        if: inputs.pre-build-command != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRE_BUILD_CMD: ${{ inputs.pre-build-command }}
+        run: |
+          set -euo pipefail
+          echo "::group::pre-build-command"
+          bash -euo pipefail -c "$PRE_BUILD_CMD"
+          echo "::endgroup::"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0


### PR DESCRIPTION
Adds a \`pre-build-command\` input to build-container.yml (mirrors the one on build-go-attest.yml from PR #26). Runs shell after checkout and before docker build, with \`GH_TOKEN\` exported.

## Motivation

ofelia's Dockerfile consumes pre-built binaries (\`COPY bin/ofelia-linux-*\`) via a binary-selector stage. To migrate ofelia's release workflow to call this reusable, we need a way to download release binaries into the build context before the docker build runs.

Without this hook, ofelia would have to either rebuild in its Dockerfile (losing the provenance tie between released binary and image's binary — different hashes) or keep its container build inline (no unification).

## Test plan

- [ ] actionlint passes
- [ ] Existing callers (lsspc, ldap-manager, raybeam) unaffected (default empty string → step is conditionally skipped)
- [ ] ofelia caller can run \`gh release download\` via this hook before docker build