### PR TITLE
docs(reusables): clarify caller permission requirements

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -73,10 +73,26 @@ on:
         description: "Newline-separated list of pushed tags (from docker/metadata-action). Empty when push=false."
         value: ${{ jobs.build.outputs.tags }}
 
-# Note on permissions: the reusable workflow declares the maximum set it
-# *may* use. GitHub clamps to the caller's granted permissions, so
-# callers that enable `sign: true` or `attest: true` MUST also grant
-# `id-token: write` and `attestations: write` at their job level.
+# CALLER REQUIREMENTS
+# ===================
+# When calling this reusable workflow, the caller's job-level
+# `permissions:` block MUST grant at least this full set, otherwise
+# push-event runs fail with `startup_failure` before any job runs
+# (GitHub rejects the workflow at startup when the reusable declares
+# permissions not covered by the caller — even if the specific
+# permission is only needed for an optional feature like sign/attest).
+#
+#   jobs:
+#     build:
+#       uses: netresearch/.github/.github/workflows/build-container.yml@main
+#       permissions:
+#         contents: read
+#         packages: write
+#         security-events: write
+#         id-token: write       # required — even when sign/attest=false
+#         attestations: write   # required — even when sign/attest=false
+#       with:
+#         image-name: my-app
 permissions:
   contents: read
   packages: write

--- a/.github/workflows/build-go-attest.yml
+++ b/.github/workflows/build-go-attest.yml
@@ -91,7 +91,26 @@ on:
         type: string
         default: ""
 
-# Least privilege: only request write permissions for jobs that need them
+# CALLER REQUIREMENTS
+# ===================
+# When calling this reusable workflow, the caller's job-level
+# `permissions:` block MUST grant at least this full set (plus
+# `contents: write` when `upload-to-release: true`). Otherwise
+# push-event runs fail with `startup_failure` before any job runs —
+# GitHub rejects the workflow at startup when the reusable declares
+# permissions the caller hasn't granted.
+#
+#   jobs:
+#     build:
+#       uses: netresearch/.github/.github/workflows/build-go-attest.yml@main
+#       permissions:
+#         contents: write        # required for release asset upload
+#         id-token: write        # required for provenance attestation
+#         attestations: write    # required for provenance attestation
+#       with:
+#         binary-name: my-app-linux-amd64
+#         goos: linux
+#         goarch: amd64
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/build-go-attest.yml
+++ b/.github/workflows/build-go-attest.yml
@@ -94,11 +94,11 @@ on:
 # CALLER REQUIREMENTS
 # ===================
 # When calling this reusable workflow, the caller's job-level
-# `permissions:` block MUST grant at least this full set (plus
-# `contents: write` when `upload-to-release: true`). Otherwise
-# push-event runs fail with `startup_failure` before any job runs —
-# GitHub rejects the workflow at startup when the reusable declares
-# permissions the caller hasn't granted.
+# `permissions:` block MUST grant at least this full set (the job
+# requests `contents: write` unconditionally for release-asset
+# uploads). Otherwise push-event runs fail with `startup_failure`
+# before any job runs — GitHub rejects the workflow at startup when
+# the reusable declares permissions the caller hasn't granted.
 #
 #   jobs:
 #     build:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -56,6 +56,15 @@ on:
         description: "The commit SHA the tag points at. Use this (not github.sha) in downstream ldflags/build-args so workflow_dispatch backfills produce correct provenance."
         value: ${{ jobs.release.outputs.sha }}
 
+# CALLER REQUIREMENTS
+# ===================
+# The caller's job-level `permissions:` block MUST grant at least:
+#
+#   jobs:
+#     create-release:
+#       uses: netresearch/.github/.github/workflows/create-release.yml@main
+#       permissions:
+#         contents: write        # create/edit the GitHub Release
 permissions:
   contents: read
 

--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -34,6 +34,20 @@ on:
         type: string
         default: ""
 
+# CALLER REQUIREMENTS
+# ===================
+# The caller's job-level `permissions:` block MUST grant at least:
+#
+#   jobs:
+#     finalize:
+#       uses: netresearch/.github/.github/workflows/finalize-release.yml@main
+#       permissions:
+#         contents: write        # upload checksums; edit release notes
+#         id-token: write        # cosign keyless + attestation
+#         attestations: write    # build-provenance for checksums
+#       with:
+#         tag: ${{ needs.create-release.outputs.tag }}
+#         image-ref: ghcr.io/${{ github.repository_owner }}/my-app
 permissions:
   contents: read
 


### PR DESCRIPTION
Adds a \`CALLER REQUIREMENTS\` block to each of the four release-pipeline reusables (\`create-release\`, \`build-container\`, \`build-go-attest\`, \`finalize-release\`) documenting the exact job-level permissions the caller must grant.

## Motivation

After \`build-container.yml\` added \`id-token\`/\`attestations\` permissions (for the sign/attest features in #23), three caller repos (\`ldap-selfservice-password-changer\`, \`ldap-manager\`, \`raybeam\`) started hitting \`startup_failure\` on push-event runs — **even when sign/attest were not enabled**. GitHub rejects the workflow run at startup when the reusable declares permissions the caller hasn't granted, regardless of whether the specific permission is actually used in the run.

Fix-up PRs on the three affected repos: [lsspc#535](https://github.com/netresearch/ldap-selfservice-password-changer/pull/535), [ldap-manager#534](https://github.com/netresearch/ldap-manager/pull/534), [raybeam#198](https://github.com/netresearch/raybeam/pull/198) — granted the missing permissions.

The previous comment on \`build-container.yml\` said *"callers that enable \`sign: true\` or \`attest: true\` MUST grant..."* — that was incorrect. Callers must grant them unconditionally, because GitHub's validation runs at startup before the conditional \`if:\` expressions on those steps are evaluated.

## What changes

- **build-container.yml** — replaces the previous partial comment with a full CALLER REQUIREMENTS block including a ready-to-copy caller snippet.
- **build-go-attest.yml** — same block, with \`contents: write\` noted as required when \`upload-to-release: true\`.
- **create-release.yml** — adds the block (caller needs \`contents: write\` only).
- **finalize-release.yml** — adds the block (caller needs \`contents: write\`, \`id-token: write\`, \`attestations: write\`).

## Test plan

- [ ] actionlint passes
- [ ] yamllint passes
- [ ] Future adopters copy-paste the caller snippet from the file header instead of learning the hard way.