### PR TITLE
feat(workflows): add go-check and ts-check reusables

### DIFF
--- a/.github/workflows/go-check.yml
+++ b/.github/workflows/go-check.yml
@@ -1,0 +1,300 @@
+# Reusable "Go check" workflow — the canonical build / test / lint / security
+# pipeline for Go projects in this org.
+#
+# Jobs (each can be toggled via inputs):
+#   - build-test   : go build + go vet + go test (with optional pre-build-cmd
+#                    for projects whose Go code depends on front-end assets)
+#   - golangci     : golangci-lint via the official action
+#   - govulncheck  : Go vulnerability database scan, fails on fixable vulns
+#   - gosec        : gosec security scan, uploads SARIF
+#
+# Caller pattern:
+#
+#   jobs:
+#     checks:
+#       uses: netresearch/.github/.github/workflows/go-check.yml@main
+#       with:
+#         enable-codecov: true
+#         setup-bun: true
+#         pre-build-cmd: "bun install --frozen-lockfile && bun run build:assets"
+#       secrets:
+#         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+#
+# SECURITY: every caller-supplied input that lands in a `run:` step is
+# pushed through the `env:` block so it cannot break out of its argument
+# position via quoting/metacharacters.
+
+name: Go Check (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      go-version-file:
+        description: "Path to go.mod / go.work / .go-version for version detection."
+        type: string
+        default: "go.mod"
+      runs-on:
+        description: "Runner label."
+        type: string
+        default: "ubuntu-latest"
+      timeout-minutes:
+        description: "Per-job timeout in minutes."
+        type: number
+        default: 15
+
+      setup-bun:
+        description: "Install Bun before running pre-build-cmd."
+        type: boolean
+        default: false
+      bun-version:
+        description: "Bun version to install (passed to oven-sh/setup-bun)."
+        type: string
+        default: "latest"
+      pre-build-cmd:
+        description: "Shell command to run before go build / test (e.g. 'bun run build:assets')."
+        type: string
+        default: ""
+
+      enable-build-test:
+        description: "Enable the build + vet + test job."
+        type: boolean
+        default: true
+      build-target:
+        description: "Argument passed to `go build -v` and `go vet`."
+        type: string
+        default: "./..."
+      test-packages:
+        description: "Packages to run `go test` against."
+        type: string
+        default: "./..."
+      test-flags:
+        description: "Flags passed to `go test` (before packages)."
+        type: string
+        default: "-race -coverprofile=coverage.out -covermode=atomic"
+
+      enable-codecov:
+        description: "Upload coverage.out to Codecov after tests."
+        type: boolean
+        default: false
+      codecov-flags:
+        description: "Codecov `flags` input."
+        type: string
+        default: "unittests"
+      codecov-file:
+        description: "Coverage file to upload."
+        type: string
+        default: "coverage.out"
+
+      enable-golangci-lint:
+        description: "Enable the golangci-lint job."
+        type: boolean
+        default: true
+      golangci-lint-version:
+        description: "golangci-lint version (passed to the action)."
+        type: string
+        default: "latest"
+      golangci-lint-args:
+        description: "Extra args for golangci-lint run."
+        type: string
+        default: ""
+
+      enable-govulncheck:
+        description: "Enable the govulncheck job. Fails when fixable vulns exist."
+        type: boolean
+        default: true
+      govulncheck-version:
+        description: "govulncheck version (go run target)."
+        type: string
+        default: "latest"
+
+      enable-gosec:
+        description: "Enable the gosec security-scan job (SARIF uploaded)."
+        type: boolean
+        default: true
+
+    secrets:
+      CODECOV_TOKEN:
+        description: "Codecov upload token (only needed when enable-codecov=true)."
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  build-test:
+    name: Build & Test
+    if: ${{ inputs.enable-build-test }}
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: ${{ inputs.go-version-file }}
+          cache: true
+
+      - name: Set up Bun
+        if: ${{ inputs.setup-bun }}
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: ${{ inputs.bun-version }}
+
+      - name: Pre-build command
+        if: ${{ inputs.pre-build-cmd != '' }}
+        env:
+          PRE_BUILD_CMD: ${{ inputs.pre-build-cmd }}
+        run: |
+          bash -c "$PRE_BUILD_CMD"
+
+      - name: Download Go modules
+        run: go mod download
+
+      - name: go vet
+        env:
+          BUILD_TARGET: ${{ inputs.build-target }}
+        run: go vet "$BUILD_TARGET"
+
+      - name: go build
+        env:
+          BUILD_TARGET: ${{ inputs.build-target }}
+        run: go build -v "$BUILD_TARGET"
+
+      - name: go test
+        env:
+          TEST_FLAGS: ${{ inputs.test-flags }}
+          TEST_PACKAGES: ${{ inputs.test-packages }}
+        run: |
+          # shellcheck disable=SC2086  # TEST_FLAGS is a space-separated flag list by design
+          go test -v $TEST_FLAGS "$TEST_PACKAGES"
+
+      - name: Upload coverage to Codecov
+        if: ${{ inputs.enable-codecov }}
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ inputs.codecov-file }}
+          flags: ${{ inputs.codecov-flags }}
+          fail_ci_if_error: false
+
+  golangci-lint:
+    name: golangci-lint
+    if: ${{ inputs.enable-golangci-lint }}
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: ${{ inputs.go-version-file }}
+          cache: true
+
+      - name: Set up Bun
+        if: ${{ inputs.setup-bun }}
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: ${{ inputs.bun-version }}
+
+      - name: Pre-build command
+        if: ${{ inputs.pre-build-cmd != '' }}
+        env:
+          PRE_BUILD_CMD: ${{ inputs.pre-build-cmd }}
+        run: |
+          bash -c "$PRE_BUILD_CMD"
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          version: ${{ inputs.golangci-lint-version }}
+          args: ${{ inputs.golangci-lint-args }}
+
+  govulncheck:
+    name: govulncheck
+    if: ${{ inputs.enable-govulncheck }}
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: ${{ inputs.go-version-file }}
+          cache: true
+
+      - name: Run govulncheck
+        env:
+          VULNCHECK_VERSION: ${{ inputs.govulncheck-version }}
+        run: |
+          set +e
+          TMP_OUT="$(mktemp)"
+          go run "golang.org/x/vuln/cmd/govulncheck@${VULNCHECK_VERSION}" ./... | tee "$TMP_OUT"
+          set -e
+          if grep -E "^\s*Fixed in:\s+" "$TMP_OUT" | grep -v "Fixed in: N/A" >/dev/null; then
+            echo "::error::govulncheck found vulnerabilities with available fixes"
+            exit 1
+          fi
+          echo "govulncheck: no fixable vulnerabilities"
+
+  gosec:
+    name: gosec
+    if: ${{ inputs.enable-gosec }}
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run gosec
+        uses: securego/gosec@64b97151cd7b978abdf8d2f1159a4e9096a12c2b # master
+        with:
+          args: "-fmt sarif -out gosec-results.sarif ./..."
+
+      - name: Upload gosec SARIF
+        if: always() && hashFiles('gosec-results.sarif') != ''
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+        with:
+          sarif_file: gosec-results.sarif

--- a/.github/workflows/ts-check.yml
+++ b/.github/workflows/ts-check.yml
@@ -1,0 +1,210 @@
+# Reusable "TypeScript / frontend check" workflow.
+#
+# Jobs (each can be toggled via inputs):
+#   - type-check   : bun install + tsc / bun run js:build
+#   - lint         : eslint via `bun run lint`
+#   - format-check : `bunx prettier --check .`
+#
+# Caller pattern:
+#
+#   jobs:
+#     ts:
+#       uses: netresearch/.github/.github/workflows/ts-check.yml@main
+#       with:
+#         install-args: "--frozen-lockfile"
+#
+# SECURITY: caller-supplied commands are routed through `env:` so the
+# caller can't break out of argument position via quoting/metacharacters.
+
+name: TS Check (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        description: "Runner label."
+        type: string
+        default: "ubuntu-latest"
+      timeout-minutes:
+        description: "Per-job timeout in minutes."
+        type: number
+        default: 10
+
+      bun-version:
+        description: "Bun version passed to oven-sh/setup-bun."
+        type: string
+        default: "latest"
+      install-cmd:
+        description: "Dependency install command."
+        type: string
+        default: "bun install --frozen-lockfile"
+
+      pre-command:
+        description: "Optional shell command to run after install but before the checks (e.g. 'go install github.com/a-h/templ/cmd/templ@latest')."
+        type: string
+        default: ""
+
+      setup-go:
+        description: "Install Go before running pre-command (useful for projects that run Go tooling as part of the TS build chain)."
+        type: boolean
+        default: false
+      go-version-file:
+        description: "Path to go.mod / .go-version for version detection when setup-go=true."
+        type: string
+        default: "go.mod"
+
+      enable-type-check:
+        description: "Run the TypeScript type-check job."
+        type: boolean
+        default: true
+      type-check-cmd:
+        description: "Command used for the type-check job."
+        type: string
+        default: "bun run js:build"
+
+      enable-lint:
+        description: "Run the ESLint job."
+        type: boolean
+        default: true
+      lint-cmd:
+        description: "Command used for the lint job."
+        type: string
+        default: "bun run lint"
+
+      enable-format-check:
+        description: "Run the Prettier format check."
+        type: boolean
+        default: true
+      format-check-cmd:
+        description: "Command used for the format-check job."
+        type: string
+        default: "bunx prettier --check ."
+
+permissions:
+  contents: read
+
+jobs:
+  type-check:
+    name: Check types
+    if: ${{ inputs.enable-type-check }}
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        if: ${{ inputs.setup-go }}
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: ${{ inputs.go-version-file }}
+          cache: true
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: ${{ inputs.bun-version }}
+
+      - name: Install dependencies
+        env:
+          INSTALL_CMD: ${{ inputs.install-cmd }}
+        run: bash -c "$INSTALL_CMD"
+
+      - name: Pre-check command
+        if: ${{ inputs.pre-command != '' }}
+        env:
+          PRE_COMMAND: ${{ inputs.pre-command }}
+        run: bash -c "$PRE_COMMAND"
+
+      - name: Type check
+        env:
+          TYPE_CHECK_CMD: ${{ inputs.type-check-cmd }}
+        run: bash -c "$TYPE_CHECK_CMD"
+
+  lint:
+    name: Lint
+    if: ${{ inputs.enable-lint }}
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        if: ${{ inputs.setup-go }}
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: ${{ inputs.go-version-file }}
+          cache: true
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: ${{ inputs.bun-version }}
+
+      - name: Install dependencies
+        env:
+          INSTALL_CMD: ${{ inputs.install-cmd }}
+        run: bash -c "$INSTALL_CMD"
+
+      - name: Pre-check command
+        if: ${{ inputs.pre-command != '' }}
+        env:
+          PRE_COMMAND: ${{ inputs.pre-command }}
+        run: bash -c "$PRE_COMMAND"
+
+      - name: Lint
+        env:
+          LINT_CMD: ${{ inputs.lint-cmd }}
+        run: bash -c "$LINT_CMD"
+
+  format-check:
+    name: Check formatting
+    if: ${{ inputs.enable-format-check }}
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: ${{ inputs.bun-version }}
+
+      - name: Install dependencies
+        env:
+          INSTALL_CMD: ${{ inputs.install-cmd }}
+        run: bash -c "$INSTALL_CMD"
+
+      - name: Format check
+        env:
+          FORMAT_CHECK_CMD: ${{ inputs.format-check-cmd }}
+        run: bash -c "$FORMAT_CHECK_CMD"


### PR DESCRIPTION
## Context

Audit of our Go projects (ldap-selfservice-password-changer, ldap-manager, simple-ldap-go, raybeam) found ~90 direct-action invocations across their CI workflows, with each repo re-implementing essentially the same Go build + test + lint + security scan pipeline. This PR adds two reusables so every Go repo can call the same pipeline and keep the same high standard — no more drift across repos.

## What

**`go-check.yml`** — canonical Go CI pipeline with four togglable jobs:
- \`build-test\`: \`go mod download\` + \`go vet\` + \`go build\` + \`go test\` with coverage. Optional \`pre-build-cmd\` + \`setup-bun\` for repos whose Go code depends on embedded frontend assets (e.g. ldap-selfservice-password-changer).
- \`golangci-lint\`: official golangci-lint action.
- \`govulncheck\`: vulnerability database scan. Fails on fixable vulns.
- \`gosec\`: security scan, uploads SARIF to the code-scanning dashboard.

Codecov upload is wired to the \`CODECOV_TOKEN\` secret (optional).

**\`ts-check.yml\`** — canonical frontend pipeline (Bun + TypeScript + Prettier) with three togglable jobs:
- \`type-check\`: \`bun install\` + \`bun run js:build\`
- \`lint\`: \`bun run lint\`
- \`format-check\`: \`bunx prettier --check .\`

Optional \`setup-go\` for projects that run Go tooling inside the TS build chain (e.g. templ, goreleaser config).

## Security

Every caller-supplied value that reaches a \`run:\` step goes through \`env:\` (no \`\${{ ... }}\` interpolation inside shell). This is the hardening pattern from https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/ — even though \`workflow_call\` inputs are controlled by the caller repo (not end-users), applying the pattern by default means we can't accidentally introduce an injection path later.

## Caller pattern

\`\`\`yaml
jobs:
  go:
    uses: netresearch/.github/.github/workflows/go-check.yml@main
    with:
      enable-codecov: true
      setup-bun: true
      pre-build-cmd: \"bun install --frozen-lockfile && bun run build:assets\"
    secrets:
      CODECOV_TOKEN: \${{ secrets.CODECOV_TOKEN }}

  ts:
    uses: netresearch/.github/.github/workflows/ts-check.yml@main
\`\`\`

## Follow-up PRs

Once this merges, one PR per Go repo will migrate the direct actions to callers of these reusables. Estimated net delta: ~−90 direct calls across the four repos; each repo's \`check.yml\` / \`ci.yml\` shrinks from ~150 lines to ~15.

## Verified

- \`actionlint\` clean, no shellcheck warnings
- Inline \`# shellcheck disable=SC2086\` where intentional (TEST_FLAGS is a space-separated flag list by design)