### PR TITLE
fix(workflows): split ci.yml lints into reusables, fix codeql per-language

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,53 +10,14 @@ permissions:
   contents: read
 
 jobs:
-  lint-workflows:
+  workflows:
     name: Lint Workflows
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
-        with:
-          egress-policy: audit
+    uses: ./.github/workflows/lint-workflows.yml
 
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: actionlint
-        uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0
-        with:
-          fail_level: error
-
-  lint-markdown:
+  markdown:
     name: Lint Markdown
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
-        with:
-          egress-policy: audit
+    uses: ./.github/workflows/lint-markdown.yml
 
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@ce4853d43830c74c1753b39f3cf40f71c2031eb9 # v23.0.0
-        with:
-          globs: "**/*.md"
-
-  lint-yaml:
+  yaml:
     name: Lint YAML
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: yamllint
-        run: |
-          pip install --quiet yamllint
-          yamllint -d "{extends: default, rules: {line-length: disable, truthy: disable, document-start: disable}}" .
+    uses: ./.github/workflows/lint-yaml.yml

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,24 +1,75 @@
 name: CodeQL
 
+# Reusable CodeQL analysis.
+#
+# The `languages` input accepts either a single CodeQL language or a
+# comma-separated list (e.g. `go` or `go,javascript-typescript`). A
+# `prepare` job normalizes the input into a JSON array, then `analyze`
+# fans out as a matrix so that each language gets its own init+analyse
+# pass and emits a distinct `/language:<lang>` SARIF category.
+#
+# Callers passing a single language keep working unchanged (1-element
+# matrix). Callers passing multiple languages now get correct per-
+# language SARIF categories instead of a single colliding one.
+
 on:
   workflow_call:
     inputs:
       languages:
-        description: CodeQL languages to analyze (comma-separated)
+        description: "CodeQL language or comma-separated list of languages to analyze."
         type: string
         default: actions
 
 permissions: {}
 
 jobs:
+  prepare:
+    name: Prepare languages
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+    outputs:
+      languages: ${{ steps.split.outputs.languages }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
+
+      - name: Split languages into JSON array
+        id: split
+        env:
+          LANGUAGES: ${{ inputs.languages }}
+        run: |
+          set -euo pipefail
+          # Normalize: strip whitespace, drop empties, emit a JSON array.
+          json="$(
+            printf '%s' "$LANGUAGES" \
+              | tr ',' '\n' \
+              | awk 'NF { gsub(/^[ \t]+|[ \t]+$/, "", $0); if ($0 != "") print }' \
+              | jq -R . \
+              | jq -s -c .
+          )"
+          if [ "$json" = "[]" ]; then
+            echo "::error::No languages provided to codeql.yml (input 'languages' is empty)."
+            exit 1
+          fi
+          echo "languages=$json" >> "$GITHUB_OUTPUT"
+
   analyze:
-    name: Analyze
+    name: Analyze (${{ matrix.language }})
+    needs: prepare
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
       security-events: write
       actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ${{ fromJSON(needs.prepare.outputs.languages) }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
@@ -33,10 +84,10 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:
-          languages: ${{ inputs.languages }}
+          languages: ${{ matrix.language }}
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:
-          category: /language:${{ inputs.languages }}
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -1,0 +1,59 @@
+# Reusable "Lint Markdown" — runs markdownlint-cli2 over the caller's
+# Markdown files.
+#
+# Caller pattern:
+#
+#   jobs:
+#     markdown:
+#       uses: netresearch/.github/.github/workflows/lint-markdown.yml@main
+#       with:
+#         globs: "**/*.md"
+#
+# SECURITY: pinned action SHAs, harden-runner, read-only permissions,
+# `persist-credentials: false` on checkout. The `globs` input is forwarded
+# to the action's own `globs` parameter (not into a `run:` step), so it
+# does not need `env:` hardening.
+
+name: Lint Markdown (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        description: "Runner label."
+        type: string
+        default: "ubuntu-latest"
+      timeout-minutes:
+        description: "Per-job timeout in minutes."
+        type: number
+        default: 5
+      globs:
+        description: "Glob(s) of Markdown files to lint (passed to markdownlint-cli2-action)."
+        type: string
+        default: "**/*.md"
+
+permissions:
+  contents: read
+
+jobs:
+  markdownlint:
+    name: markdownlint
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@ce4853d43830c74c1753b39f3cf40f71c2031eb9 # v23.0.0
+        with:
+          globs: ${{ inputs.globs }}

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,51 @@
+# Reusable "Lint Workflows" — runs actionlint against the caller's
+# `.github/workflows/` directory.
+#
+# Caller pattern:
+#
+#   jobs:
+#     workflows:
+#       uses: netresearch/.github/.github/workflows/lint-workflows.yml@main
+#
+# SECURITY: pinned action SHAs, harden-runner, read-only permissions,
+# `persist-credentials: false` on checkout.
+
+name: Lint Workflows (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        description: "Runner label."
+        type: string
+        default: "ubuntu-latest"
+      timeout-minutes:
+        description: "Per-job timeout in minutes."
+        type: number
+        default: 5
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: actionlint
+        uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0
+        with:
+          fail_level: error

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -1,0 +1,70 @@
+# Reusable "Lint YAML" — runs yamllint over the caller's repository.
+#
+# The yamllint config is the same inline defaults previously used by this
+# repo's `ci.yml`:
+#   extends: default
+#   rules:
+#     line-length: disable
+#     truthy: disable
+#     document-start: disable
+#
+# If the caller repo ships its own `.yamllint`, `.yamllint.yml`, or
+# `.yamllint.yaml`, that file is used instead (yamllint auto-discovers it
+# in the working directory, taking precedence over the `-d` default).
+#
+# Caller pattern:
+#
+#   jobs:
+#     yaml:
+#       uses: netresearch/.github/.github/workflows/lint-yaml.yml@main
+#
+# SECURITY: pinned action SHAs, harden-runner, read-only permissions,
+# `persist-credentials: false` on checkout.
+
+name: Lint YAML (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        description: "Runner label."
+        type: string
+        default: "ubuntu-latest"
+      timeout-minutes:
+        description: "Per-job timeout in minutes."
+        type: number
+        default: 5
+
+permissions:
+  contents: read
+
+jobs:
+  yamllint:
+    name: yamllint
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: yamllint
+        env:
+          YAMLLINT_DEFAULT_CONFIG: "{extends: default, rules: {line-length: disable, truthy: disable, document-start: disable}}"
+        run: |
+          pip install --quiet yamllint
+          # If the caller repo has its own yamllint config file, prefer it;
+          # otherwise fall back to our inline defaults.
+          if [ -f .yamllint ] || [ -f .yamllint.yml ] || [ -f .yamllint.yaml ]; then
+            yamllint .
+          else
+            yamllint -d "$YAMLLINT_DEFAULT_CONFIG" .
+          fi


### PR DESCRIPTION
## Summary

Two fixes that caller repositories hit when adopting this org's reusable workflow catalog:

### Problem 1 — `ci.yml` isn't reusable

`ci.yml` shipped three lint jobs (`lint-workflows`, `lint-markdown`, `lint-yaml`) gated on `push` / `pull_request` only. A migration agent for `simple-ldap-go` tried to `uses:` it as a reusable, couldn't, and had to copy the actionlint block inline — undermining "same workflows everywhere".

**Fix:** extract each lint job into its own `workflow_call` reusable:

- `lint-workflows.yml` — actionlint (`fail_level: error`). Inputs: `runs-on`, `timeout-minutes`.
- `lint-markdown.yml` — markdownlint-cli2. Inputs: `runs-on`, `timeout-minutes`, `globs` (default `**/*.md`).
- `lint-yaml.yml` — yamllint. Inputs: `runs-on`, `timeout-minutes`. Preserves the previous inline config (`{extends: default, rules: {line-length: disable, truthy: disable, document-start: disable}}`) and auto-prefers `.yamllint{,.yml,.yaml}` when the caller ships one.

`ci.yml` is rewritten to call these three reusables via `uses: ./.github/workflows/lint-*.yml` — dogfooding the new contracts without changing the CI surface.

### Problem 2 — `codeql.yml` breaks on multi-language input

Old reusable used `category: /language:${{ inputs.languages }}` literally. Passing `languages: go,javascript-typescript` produced a single broken category `/language:go,javascript-typescript` — two language analyses collide into one SARIF bucket. Two migration agents worked around this with ad-hoc matrices.

**Fix:** a `prepare` job splits the comma-separated `languages` input into a JSON array (via `$GITHUB_OUTPUT`), then `analyze` fans out as `strategy.matrix.language`, so each language gets its own `init` + `analyze` pass with a distinct `/language:<lang>` category. Single-language callers (`languages: go`) still work — they just run as a 1-element matrix.

## Migration impact

- **Existing `codeql.yml` callers:** no breaking change. Single-language callers keep working. Callers that were passing multiple languages in the same string now get correct per-language SARIF categories instead of a colliding one.
- **New lint reusables:** caller repos can `uses:` `lint-workflows.yml` / `lint-markdown.yml` / `lint-yaml.yml` independently, picking only the linters they want — no more copy/paste inline.
- **Unchanged:** `auto-merge-deps.yml`, `pr-quality.yml`, `go-check.yml`, `ts-check.yml`, `build-container.yml`, `create-release.yml`, `finalize-release.yml`.

## Hard constraints

- [x] `actionlint` clean on every modified file (verified locally; `actionlint` over the full `.github/workflows/` tree returns no findings).
- [x] All action SHAs pinned, matches existing style (`harden-runner`, `actions/checkout`, reviewdog, DavidAnson, `codeql-action`).
- [x] Per-job `permissions:` declared, read-only default; `analyze` job keeps the necessary `security-events: write`.
- [x] `step-security/harden-runner` on every job (including the new `prepare` job in `codeql.yml`).
- [x] Every caller-supplied input that reaches `run:` routed through `env:` (yamllint default config, codeql `LANGUAGES` split).
- [x] Signed + DCO on every commit.

## Commits

1. `feat(workflows): extract lint-workflows, lint-markdown, lint-yaml reusables` (b4af6df)
2. `refactor(workflows): dogfood ci.yml as a caller of the lint reusables` (abb15ba)
3. `fix(workflows): codeql — matrix per-language for correct SARIF categories` (77681d1)

## Test plan

- [ ] CI on this PR (runs the dogfooded `ci.yml`) stays green — proves all three new reusables work as callees.
- [ ] Manually smoke the codeql reusable against a 2-language caller in a follow-up PR (e.g. the `simple-ldap-go` migration) and confirm two distinct `/language:<lang>` SARIF categories appear in the security tab.