### PR TITLE
fix(go-check): apply pre-build-cmd + setup-bun to govulncheck + gosec jobs

### DIFF
--- a/.github/workflows/go-check.yml
+++ b/.github/workflows/go-check.yml
@@ -255,6 +255,19 @@ jobs:
           go-version-file: ${{ inputs.go-version-file }}
           cache: true
 
+      - name: Set up Bun
+        if: ${{ inputs.setup-bun }}
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: ${{ inputs.bun-version }}
+
+      - name: Pre-build command
+        if: ${{ inputs.pre-build-cmd != '' }}
+        env:
+          PRE_BUILD_CMD: ${{ inputs.pre-build-cmd }}
+        run: |
+          bash -c "$PRE_BUILD_CMD"
+
       - name: Run govulncheck
         env:
           VULNCHECK_VERSION: ${{ inputs.govulncheck-version }}
@@ -287,6 +300,25 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: ${{ inputs.go-version-file }}
+          cache: true
+
+      - name: Set up Bun
+        if: ${{ inputs.setup-bun }}
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: ${{ inputs.bun-version }}
+
+      - name: Pre-build command
+        if: ${{ inputs.pre-build-cmd != '' }}
+        env:
+          PRE_BUILD_CMD: ${{ inputs.pre-build-cmd }}
+        run: |
+          bash -c "$PRE_BUILD_CMD"
 
       - name: Run gosec
         uses: securego/gosec@64b97151cd7b978abdf8d2f1159a4e9096a12c2b # master


### PR DESCRIPTION
## Problem

Seen on PR netresearch/ldap-selfservice-password-changer#540 running \`Go / gosec\`:

\`\`\`
[gosec] Error building the SSA representation of the package static: package static has type errors, skipping SSA analysis, no ssa result
\`\`\`

The \`static\` package uses \`//go:embed\` on CSS/JS that bun generates. When the reusable's \`gosec\` job (and \`govulncheck\`) run, they do NOT invoke the frontend build, so the embedded files are absent and the Go package fails to type-check. gosec falls back from SSA to pattern matching and exits non-zero on the 'type errors' warnings.

## Cause

The \`setup-bun\` + \`pre-build-cmd\` pair was only applied to the \`build-test\` and \`golangci-lint\` jobs of \`go-check.yml\`. \`govulncheck\` and \`gosec\` also compile the Go code — they need the same hook.

## Fix

Apply the same steps (guarded by the existing \`if: \${{ inputs.setup-bun }}\` / \`if: \${{ inputs.pre-build-cmd != '' }}\` conditionals) to \`govulncheck\` and \`gosec\`. Callers that don't need them (pure Go libs) pass the defaults and the steps skip — no caller-side change required.

Also added \`Set up Go\` to \`gosec\`. Previously absent; gosec's binary doesn't need Go on PATH, but SSA fallback scanning does.

## Verified

- \`actionlint\` clean
- Affected caller (ldap-selfservice-password-changer#540) should pass on next run