### PR TITLE
feat(go-check): forward golangci-lint verify input

### DIFF
--- a/.github/workflows/go-check.yml
+++ b/.github/workflows/go-check.yml
@@ -101,6 +101,10 @@ on:
         description: "install-mode for golangci-lint-action. 'goinstall' compiles golangci-lint against the caller's Go toolchain — use this when your repo targets a Go version newer than the prebuilt binary."
         type: string
         default: "goinstall"
+      golangci-lint-verify:
+        description: "Run `golangci-lint config verify` before linting. Set false when the caller repo's .golangci.yml uses a schema from an older major (e.g. v1-style keys on a v2 binary). Default true — strict is safer."
+        type: boolean
+        default: true
 
       enable-govulncheck:
         description: "Enable the govulncheck job."
@@ -242,6 +246,7 @@ jobs:
           # avoiding binary/repo Go-version mismatches when the repo targets
           # a newer Go than the latest prebuilt binary.
           install-mode: ${{ inputs.golangci-lint-install-mode }}
+          verify: ${{ inputs.golangci-lint-verify }}
 
   govulncheck:
     name: govulncheck


### PR DESCRIPTION
Surfaced on ldap-manager's migration PR — its \`.golangci.yml\` still uses v1-schema keys (\`exclude-use-default\`, \`linters-settings\`, \`version: 1\` as number, etc.) so golangci-lint v2's \`config verify\` preflight hard-fails before actual linting runs.

Expose the action's existing \`verify\` input so callers mid-migration can pass \`golangci-lint-verify: false\`, while strict repos keep the default \`true\`.

Config migration in ldap-manager is a separate cleanup.

Verified actionlint clean.