### PR TITLE
feat: add safe-updates-only + merge-strategy inputs to auto-merge-deps

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -3,6 +3,23 @@ name: Auto-merge dependency PRs
 on:
   pull_request:
   workflow_call:
+    inputs:
+      safe-updates-only:
+        description: >-
+          When true, only auto-merge safe updates (semver minor/patch for
+          Dependabot, or Docker non-major bumps). Majors are approved but
+          left for a human to merge. Renovate is always trusted — its own
+          config (renovate.json) decides what it opens.
+        type: boolean
+        default: false
+      merge-strategy:
+        description: >-
+          Override the merge strategy. One of "squash", "merge", "rebase",
+          or "" (default) to auto-detect from repo settings. Use this when
+          the repo has `required_linear_history` or other constraints the
+          auto-detector can't see.
+        type: string
+        default: ""
 
 permissions: {}
 
@@ -27,16 +44,35 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr review --approve "$PR_URL"
 
+      - name: Dependabot metadata
+        id: metadata
+        if: inputs.safe-updates-only && github.event.pull_request.user.login == 'dependabot[bot]'
+        uses: dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36 # v3.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Enable auto-merge
+        if: >-
+          !inputs.safe-updates-only ||
+          github.event.pull_request.user.login == 'renovate[bot]' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          (steps.metadata.outputs.package-ecosystem == 'docker' &&
+           steps.metadata.outputs.update-type != 'version-update:semver-major')
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
+          STRATEGY_OVERRIDE: ${{ inputs.merge-strategy }}
         run: |
-          STRATEGY=$(gh api "repos/$REPO" --jq '
-            if .allow_squash_merge then "--squash"
-            elif .allow_merge_commit then "--merge"
-            elif .allow_rebase_merge then "--rebase"
-            else "--squash" end')
+          if [[ -n "$STRATEGY_OVERRIDE" ]]; then
+            STRATEGY="--$STRATEGY_OVERRIDE"
+          else
+            STRATEGY=$(gh api "repos/$REPO" --jq '
+              if .allow_squash_merge then "--squash"
+              elif .allow_merge_commit then "--merge"
+              elif .allow_rebase_merge then "--rebase"
+              else "--squash" end')
+          fi
           echo "Using merge strategy: $STRATEGY"
           gh pr merge --auto "$STRATEGY" "$PR_URL"


### PR DESCRIPTION
## Summary

Adds two optional inputs to the reusable `auto-merge-deps.yml` workflow so callers can opt into stricter behavior without duplicating the whole workflow inline.

## Inputs

- **`safe-updates-only`** (bool, default `false`) — when `true`, only auto-merge:
  - Dependabot PRs with `update-type` == `version-update:semver-minor` or `semver-patch`
  - Dependabot Docker bumps that are **not** `semver-major`
  - Renovate PRs (always trusted — its own config gates what it opens)
  
  Majors are approved but left for a human to merge.

- **`merge-strategy`** (string, default `""`) — override the auto-detected merge strategy. Expects `squash`, `merge`, `rebase`, or empty (auto-detect). Needed for repos with `required_linear_history` or other constraints the auto-detector can't see from repo settings alone.

## Default behavior unchanged

Both inputs default to their existing values, so all ~30 callers in skill repos + netresearch/ofelia continue working exactly as before.

## Why

- netresearch/phpbu-docker currently has a **full inline workflow** with bespoke semver gating (auto-merges minor/patch + Docker non-major; majors sit for review). Moving it to a caller required the central workflow to support the same gate.
- netresearch/phpbu-docker also has `required_linear_history: true` + `allow_merge_commit: true` which confuses the auto-detect (picks `--merge`, GitHub then rejects). The `merge-strategy` override lets the caller declare intent explicitly.
- Future repos that want stricter auto-merge semantics can now set `safe-updates-only: true` without copying the full workflow.

## Follow-up

After this merges, I'll open a PR on phpbu-docker migrating it to a caller with `safe-updates-only: true` and `merge-strategy: rebase`.