### PR TITLE
fix(drift): scope comparison to .github/ subtree only

### DIFF
--- a/.github/workflows/check-template-drift.yml
+++ b/.github/workflows/check-template-drift.yml
@@ -151,7 +151,7 @@ jobs:
               DIFFERING+=("$rel")
               DRIFT_FOUND=1
             fi
-          done < <(find "$TEMPLATE_ROOT" -type f -print0)
+          done < <(find "$TEMPLATE_ROOT/.github" -type f -print0)
 
           if [ "$DRIFT_FOUND" = "0" ]; then
             echo "::notice::No drift detected against template '${TEMPLATE_NAME}'."

--- a/scripts/check-drift.sh
+++ b/scripts/check-drift.sh
@@ -63,7 +63,7 @@ while IFS= read -r -d '' tpl_file; do
   if ! diff -q "$tpl_file" "$consumer_path" >/dev/null 2>&1; then
     DIFFERING+=("$rel")
   fi
-done < <(find "$TEMPLATE_ROOT" -type f -print0)
+done < <(find "$TEMPLATE_ROOT/.github" -type f -print0)
 
 if [ ${#MISSING[@]} -eq 0 ] && [ ${#DIFFERING[@]} -eq 0 ]; then
   echo "No drift."


### PR DESCRIPTION
Drift check compared template's top-level `README.md` (template docs) against the consumer's own `README.md` and always flagged drift. Fixes all 6 Wave 1–3 sync PR false-positive failures in one line. Scope the `find` walk to `$TEMPLATE_ROOT/.github`.