### PR TITLE
fix(scripts): drift context name for branch protection

### DIFF
--- a/scripts/apply-branch-protection.sh
+++ b/scripts/apply-branch-protection.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-DRIFT_CONTEXT="Template Drift / drift"
+DRIFT_CONTEXT="drift / Template drift"
 
 declare -A CONSUMERS=(
   [netresearch/ofelia]=go-app


### PR DESCRIPTION
Fix typo in `scripts/apply-branch-protection.sh` — drift context is `drift / Template drift`, not `Template Drift / drift`. Spotted while preparing Wave 4 enforcement.