### PR TITLE
fix(templates): address follow-ups flagged during Wave 1-3 reviews

### DIFF
--- a/templates/go-app/.github/dependabot.yml
+++ b/templates/go-app/.github/dependabot.yml
@@ -29,3 +29,10 @@ updates:
     groups:
       docker:
         patterns: ['*']
+
+  - package-ecosystem: devcontainers
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 2

--- a/templates/go-app/.github/labeler.yml
+++ b/templates/go-app/.github/labeler.yml
@@ -3,10 +3,10 @@ documentation:
       - any-glob-to-any-file: ['**/*.md', 'docs/**/*']
 ci:
   - changed-files:
-      - any-glob-to-any-file: ['.github/**/*']
+      - any-glob-to-any-file: ['.github/**/*', 'Makefile']
 dependencies:
   - changed-files:
-      - any-glob-to-any-file: ['go.mod', 'go.sum']
+      - any-glob-to-any-file: ['go.mod', 'go.sum', 'Dockerfile', '.devcontainer/**/*']
 tests:
   - changed-files:
       - any-glob-to-any-file: ['**/*_test.go', 'testdata/**/*']

--- a/templates/go-app/.github/workflows/container-retention.yml
+++ b/templates/go-app/.github/workflows/container-retention.yml
@@ -17,7 +17,7 @@ jobs:
     uses: netresearch/.github/.github/workflows/ghcr-retention.yml@main
     with:
       package-name: ${{ github.event.repository.name }}
-      dry-run: ${{ inputs.dry-run != false }}
+      dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run }}
     permissions:
       packages: write
       attestations: read

--- a/templates/go-app/.github/workflows/release.yml
+++ b/templates/go-app/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
   create:
     uses: netresearch/.github/.github/workflows/create-release.yml@main
     with:
-      tag: ${{ inputs.tag || '' }}
+      tag: ${{ inputs.tag || github.ref_name }}
     permissions:
       contents: write
 

--- a/templates/go-lib/.github/dependabot.yml
+++ b/templates/go-lib/.github/dependabot.yml
@@ -29,3 +29,10 @@ updates:
     groups:
       docker:
         patterns: ['*']
+
+  - package-ecosystem: devcontainers
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 2

--- a/templates/go-lib/.github/labeler.yml
+++ b/templates/go-lib/.github/labeler.yml
@@ -3,10 +3,10 @@ documentation:
       - any-glob-to-any-file: ['**/*.md', 'docs/**/*']
 ci:
   - changed-files:
-      - any-glob-to-any-file: ['.github/**/*']
+      - any-glob-to-any-file: ['.github/**/*', 'Makefile']
 dependencies:
   - changed-files:
-      - any-glob-to-any-file: ['go.mod', 'go.sum']
+      - any-glob-to-any-file: ['go.mod', 'go.sum', 'Dockerfile', '.devcontainer/**/*']
 tests:
   - changed-files:
       - any-glob-to-any-file: ['**/*_test.go', 'testdata/**/*']


### PR DESCRIPTION
Template bug fixes from the fleet-wide sync review comments:

1. `release.yml` — tag fallback now `github.ref_name` (was `''` which broke push-tag triggered releases)
2. `container-retention.yml` — dry-run expression was inverted; scheduled cleanups never deleted anything. Now schedule=delete, dispatch=respect input default.
3. `dependabot.yml` — `devcontainers` ecosystem added
4. `labeler.yml` — Dockerfile/devcontainer in `dependencies`, Makefile in `ci`

Applies to both go-app and go-lib templates. After merge, running `scripts/sync-all-consumers.sh` will open 6 PRs (one per consumer) carrying these fixes into each repo.

Follows up netresearch/.github#47.