### PR TITLE
fix(templates): run drift check in merge_group context

### DIFF
--- a/templates/go-app/.github/workflows/check-template-drift.yml
+++ b/templates/go-app/.github/workflows/check-template-drift.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   push:
     branches: [main]
+  merge_group:
 
 permissions: {}
 

--- a/templates/go-lib/.github/workflows/check-template-drift.yml
+++ b/templates/go-lib/.github/workflows/check-template-drift.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   push:
     branches: [main]
+  merge_group:
 
 permissions: {}
 


### PR DESCRIPTION
Repos with a merge_queue run queued PRs under the `merge_group` event, not `pull_request`. The drift-check caller template only had `push`/`pull_request` triggers, so the required status check 'drift / Template drift' never reported in merge-queue context and the queue kept dropping PRs.

Caught via ofelia#571 which bounced out of the queue four times (all CI+Integration merge_group runs green, but drift never ran). Adding `merge_group:` to both go-app and go-lib templates' `check-template-drift.yml` callers fixes it.