### PR TITLE
fix: address review comments from Wave 0 foundation PRs

### DIFF
--- a/.github/workflows/ghcr-retention.yml
+++ b/.github/workflows/ghcr-retention.yml
@@ -247,7 +247,9 @@ jobs:
       - name: Install crane
         uses: imjasonh/setup-crane@6da1ae018866400525525ce74ff892880c099987 # v0.5
         with:
-          version: latest
+          # Pin crane to a known-good release; `latest` broke CI in the past
+          # when upstream re-tagged without backward compat.
+          version: v0.22.1
 
       - name: Log in to Container registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/.github/workflows/go-check.yml
+++ b/.github/workflows/go-check.yml
@@ -142,11 +142,6 @@ on:
         description: "Run `go test -run=Fuzz` against the repo (fuzz tests in corpus-replay mode). No-op when no FuzzXxx targets exist."
         type: boolean
         default: true
-      fuzz-timeout:
-        description: "Per-target fuzz duration (go test -fuzztime value) when running in active fuzzing mode."
-        type: string
-        default: "30s"
-
       enable-license-check:
         description: "Scan dependency licenses via google/go-licenses against the org-standard allowlist."
         type: boolean
@@ -208,7 +203,9 @@ jobs:
         env:
           PRE_BUILD_CMD: ${{ inputs.pre-build-cmd }}
         run: |
-          bash -c "$PRE_BUILD_CMD"
+          # Strict mode: surface caller script errors instead of silently
+          # continuing into the Go build with a half-built frontend.
+          bash -eu -c "$PRE_BUILD_CMD"
 
       - name: Download Go modules
         run: go mod download
@@ -289,7 +286,9 @@ jobs:
         env:
           PRE_BUILD_CMD: ${{ inputs.pre-build-cmd }}
         run: |
-          bash -c "$PRE_BUILD_CMD"
+          # Strict mode: surface caller script errors instead of silently
+          # continuing into the Go build with a half-built frontend.
+          bash -eu -c "$PRE_BUILD_CMD"
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
@@ -337,7 +336,9 @@ jobs:
         env:
           PRE_BUILD_CMD: ${{ inputs.pre-build-cmd }}
         run: |
-          bash -c "$PRE_BUILD_CMD"
+          # Strict mode: surface caller script errors instead of silently
+          # continuing into the Go build with a half-built frontend.
+          bash -eu -c "$PRE_BUILD_CMD"
 
       - name: Run govulncheck
         env:
@@ -399,7 +400,9 @@ jobs:
         env:
           PRE_BUILD_CMD: ${{ inputs.pre-build-cmd }}
         run: |
-          bash -c "$PRE_BUILD_CMD"
+          # Strict mode: surface caller script errors instead of silently
+          # continuing into the Go build with a half-built frontend.
+          bash -eu -c "$PRE_BUILD_CMD"
 
       - name: Run gosec
         uses: securego/gosec@64b97151cd7b978abdf8d2f1159a4e9096a12c2b # master
@@ -450,7 +453,9 @@ jobs:
         env:
           PRE_BUILD_CMD: ${{ inputs.pre-build-cmd }}
         run: |
-          bash -c "$PRE_BUILD_CMD"
+          # Strict mode: surface caller script errors instead of silently
+          # continuing into the Go build with a half-built frontend.
+          bash -eu -c "$PRE_BUILD_CMD"
 
       - name: go test -short (smoke)
         env:
@@ -492,7 +497,9 @@ jobs:
         env:
           PRE_BUILD_CMD: ${{ inputs.pre-build-cmd }}
         run: |
-          bash -c "$PRE_BUILD_CMD"
+          # Strict mode: surface caller script errors instead of silently
+          # continuing into the Go build with a half-built frontend.
+          bash -eu -c "$PRE_BUILD_CMD"
 
       - name: Run fuzz tests (corpus replay mode)
         # `-run=Fuzz` + no `-fuzz=` runs FuzzXxx functions as unit tests against
@@ -527,7 +534,7 @@ jobs:
           cache: true
 
       - name: Install go-licenses
-        run: go install github.com/google/go-licenses@latest
+        run: go install github.com/google/go-licenses@3e084b0caf710f7bfead967567539214f598c0a2  # pinned to avoid upstream breakage on @latest
 
       - name: Run license check
         env:

--- a/scripts/sync-template.sh
+++ b/scripts/sync-template.sh
@@ -123,7 +123,6 @@ else
   # transfer root (.github/), but intentional-drift paths are relative to
   # repo root — strip the `.github/` prefix.
   EXCLUDES=$(mktemp)
-  trap '"'"'rm -f "$EXCLUDES"'"'"' RETURN
   for p in "${DRIFT_PATHS[@]}"; do
     case "$p" in
       .github/*) echo "${p#.github/}" >> "$EXCLUDES" ;;

--- a/templates/go-app/.github/dependabot.yml
+++ b/templates/go-app/.github/dependabot.yml
@@ -36,3 +36,6 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 2
+    groups:
+      devcontainers:
+        patterns: ['*']

--- a/templates/go-lib/.github/dependabot.yml
+++ b/templates/go-lib/.github/dependabot.yml
@@ -36,3 +36,6 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 2
+    groups:
+      devcontainers:
+        patterns: ['*']


### PR DESCRIPTION
Addresses substantive feedback from review threads on the merged PRs #47, #50, #51:

- **go-check.yml**: remove unused `fuzz-timeout` input, pin `go-licenses`, strict-mode `pre-build-cmd` (`bash -eu -c`)
- **ghcr-retention.yml**: pin `setup-crane` version
- **templates dependabot.yml**: add `groups` to the devcontainers entry for consistency
- **sync-template.sh**: remove broken `trap ... RETURN` (fires on function return, not script exit)