### PR TITLE
fix: repin go-licenses to v1.6.0

### DIFF
--- a/.github/workflows/go-check.yml
+++ b/.github/workflows/go-check.yml
@@ -534,7 +534,7 @@ jobs:
           cache: true
 
       - name: Install go-licenses
-        run: go install github.com/google/go-licenses@3e084b0caf710f7bfead967567539214f598c0a2  # pinned to avoid upstream breakage on @latest
+        run: go install github.com/google/go-licenses@5348b744d0983d85713295ea08a20cca1654a45e  # pinned to v1.6.0 (post-v1 tags live in /v2 module path)
 
       - name: Run license check
         env:


### PR DESCRIPTION
Fix bad pin introduced in #53 — the SHA I picked was v2.0.1 whose go.mod uses the `/v2` module suffix, so the install command in go-check.yml fails. Repin to v1.6.0.