### PR TITLE
fix: fold CodeQL detect into reusable + container.yml perms

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,12 +37,28 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Checkout (only needed when auto-detecting)
+        if: ${{ inputs.languages == 'auto' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Split languages into JSON array
         id: split
         env:
           LANGUAGES: ${{ inputs.languages }}
         run: |
           set -euo pipefail
+          # `auto` triggers in-repo detection: Go is assumed, plus JS/TS if
+          # there's a package.json or any TS source. Explicit lists still
+          # win — pass `languages: go` or `languages: go,javascript-typescript`.
+          if [ "$LANGUAGES" = "auto" ]; then
+            langs="go"
+            if [ -f package.json ] || [ -n "$(find . -maxdepth 4 -type f \( -name '*.ts' -o -name '*.tsx' -o -name '*.mts' \) 2>/dev/null | head -1)" ]; then
+              langs="${langs},javascript-typescript"
+            fi
+            LANGUAGES="$langs"
+          fi
           # Normalize: strip whitespace, drop empties, emit a JSON array.
           json="$(
             printf '%s' "$LANGUAGES" \

--- a/templates/go-app/.github/workflows/codeql.yml
+++ b/templates/go-app/.github/workflows/codeql.yml
@@ -11,38 +11,10 @@ on:
 permissions: {}
 
 jobs:
-  detect:
-    name: Detect languages
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    permissions:
-      contents: read
-    outputs:
-      languages: ${{ steps.detect.outputs.languages }}
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
-        with:
-          egress-policy: audit
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - name: Detect TS/JS + Go
-        id: detect
-        run: |
-          set -euo pipefail
-          langs="go"
-          if [ -f package.json ] || [ -n "$(find . -maxdepth 3 -name '*.ts' -o -name '*.tsx' -o -name '*.mts' 2>/dev/null | head -1)" ]; then
-            langs="${langs},javascript-typescript"
-          fi
-          echo "languages=${langs}" >> "$GITHUB_OUTPUT"
-
   codeql:
-    needs: detect
     uses: netresearch/.github/.github/workflows/codeql.yml@main
     with:
-      languages: ${{ needs.detect.outputs.languages }}
+      languages: auto
     permissions:
       contents: read
       security-events: write

--- a/templates/go-app/.github/workflows/container.yml
+++ b/templates/go-app/.github/workflows/container.yml
@@ -22,3 +22,4 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      security-events: write

--- a/templates/go-lib/.github/workflows/codeql.yml
+++ b/templates/go-lib/.github/workflows/codeql.yml
@@ -11,38 +11,10 @@ on:
 permissions: {}
 
 jobs:
-  detect:
-    name: Detect languages
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    permissions:
-      contents: read
-    outputs:
-      languages: ${{ steps.detect.outputs.languages }}
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
-        with:
-          egress-policy: audit
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - name: Detect TS/JS + Go
-        id: detect
-        run: |
-          set -euo pipefail
-          langs="go"
-          if [ -f package.json ] || [ -n "$(find . -maxdepth 3 -name '*.ts' -o -name '*.tsx' -o -name '*.mts' 2>/dev/null | head -1)" ]; then
-            langs="${langs},javascript-typescript"
-          fi
-          echo "languages=${langs}" >> "$GITHUB_OUTPUT"
-
   codeql:
-    needs: detect
     uses: netresearch/.github/.github/workflows/codeql.yml@main
     with:
-      languages: ${{ needs.detect.outputs.languages }}
+      languages: auto
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
Three template corrections:

- **codeql.yml**: reusable grows `languages: auto` so the template caller drops its inline `detect` job + harden-runner. Kills the drift source behind 5 Dependabot PRs that bump harden-runner in each consumer.
- **container.yml**: template caller adds `security-events: write` — build-container.yml uploads trivy SARIF and the caller must grant it (workflow was failing validation on ldap-manager main).
- Ofelia's `integration.yml` will be removed in a follow-up — it's redundant with go-check's `enable-integration-tests` and is the last inline harden-runner on that repo.