### PR TITLE
docs(codeql): document languages: auto input value

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,11 +2,19 @@ name: CodeQL
 
 # Reusable CodeQL analysis.
 #
-# The `languages` input accepts either a single CodeQL language or a
-# comma-separated list (e.g. `go` or `go,javascript-typescript`). A
-# `prepare` job normalizes the input into a JSON array, then `analyze`
-# fans out as a matrix so that each language gets its own init+analyse
-# pass and emits a distinct `/language:<lang>` SARIF category.
+# The `languages` input accepts one of:
+#   - `auto` — in-repo detection: always includes `go`; adds
+#     `javascript-typescript` when a `package.json` exists or any
+#     `.ts` / `.tsx` / `.mts` source is present in the first 4 levels
+#     of the tree. This is the preferred value for Go repos since it
+#     picks up JS/TS tooling automatically.
+#   - a single CodeQL language, e.g. `go`
+#   - a comma-separated list, e.g. `go,javascript-typescript`
+#
+# A `prepare` job normalizes the input into a JSON array, then
+# `analyze` fans out as a matrix so that each language gets its own
+# init+analyse pass and emits a distinct `/language:<lang>` SARIF
+# category.
 #
 # Callers passing a single language keep working unchanged (1-element
 # matrix). Callers passing multiple languages now get correct per-
@@ -16,7 +24,11 @@ on:
   workflow_call:
     inputs:
       languages:
-        description: "CodeQL language or comma-separated list of languages to analyze."
+        description: >-
+          CodeQL language(s) to analyze. Accepts `auto` (detects `go` +
+          `javascript-typescript` when a package.json or TS source is
+          present), a single language (e.g. `go`), or a comma-separated
+          list (e.g. `go,javascript-typescript`).
         type: string
         default: actions
 


### PR DESCRIPTION
## Summary

Document the `auto` value for the reusable `codeql.yml` workflow's `languages` input. Closes [#62](https://github.com/netresearch/.github/issues/62).

- Header comment now enumerates the three accepted forms (`auto`, single language, comma-separated list) and describes what `auto` detects.
- Input description no longer stops at "single language or comma-separated list" — it names `auto` and what it resolves to.

## Test plan

- [x] Pure docs change, no logic touched.
- [x] Verified YAML still parses.