### PR TITLE
fix(gitleaks): grant security-events: write to caller template

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,10 +25,10 @@ on:
     inputs:
       languages:
         description: >-
-          CodeQL language(s) to analyze. Accepts `auto` (detects `go` +
-          `javascript-typescript` when a package.json or TS source is
-          present), a single language (e.g. `go`), or a comma-separated
-          list (e.g. `go,javascript-typescript`).
+          CodeQL language(s) to analyze. Accepts `auto` (always includes
+          `go`; adds `javascript-typescript` when a package.json or TS
+          source is present), a single language (e.g. `go`), or a
+          comma-separated list (e.g. `go,javascript-typescript`).
         type: string
         default: actions
 

--- a/templates/go-app/.github/workflows/gitleaks.yml
+++ b/templates/go-app/.github/workflows/gitleaks.yml
@@ -13,3 +13,4 @@ jobs:
     uses: netresearch/.github/.github/workflows/gitleaks.yml@main
     permissions:
       contents: read
+      security-events: write

--- a/templates/go-lib/.github/workflows/gitleaks.yml
+++ b/templates/go-lib/.github/workflows/gitleaks.yml
@@ -13,3 +13,4 @@ jobs:
     uses: netresearch/.github/.github/workflows/gitleaks.yml@main
     permissions:
       contents: read
+      security-events: write


### PR DESCRIPTION
## Summary

Two fleet-hygiene fixes in one patch.

### 1. Fleet-wide Gitleaks startup_failure (urgent)

Every consumer's Gitleaks workflow has been startup_failure'ing on main for the past 24+ hours — zero jobs executed, no SARIF uploaded, no scan coverage on main pushes. Root cause: the caller template overrides job permissions to \`contents: read\` only, but the reusable \`gitleaks.yml\` job declares \`security-events: write\` (needed to upload the SARIF). GitHub Actions rejects a caller that grants *fewer* permissions than a reusable job requires → the whole workflow fails to start.

Grant \`security-events: write\` to the caller job, matching the reusable contract. Consumers will pick it up on the next template sync.

### 2. codeql.yml description follow-up (#63)

Apply Copilot's wording suggestion on the merged [#63](https://github.com/netresearch/.github/pull/63): the \`languages: auto\` input description now says "always includes \`go\`; adds \`javascript-typescript\` when ..." to match the header comment. Resolves the open review thread on that PR.

## Test plan

- [x] YAML parses (\`python3 -c "import yaml; yaml.safe_load(open(...))"\`).
- [ ] After merge + fleet sync, a push to main on any consumer must show Gitleaks completing (not startup_failure).