### PR TITLE
fix(gitleaks): forward GITLEAKS_LICENSE org secret to reusable

### DIFF
--- a/templates/go-app/.github/workflows/gitleaks.yml
+++ b/templates/go-app/.github/workflows/gitleaks.yml
@@ -14,3 +14,5 @@ jobs:
     permissions:
       contents: read
       security-events: write
+    secrets:
+      GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/templates/go-lib/.github/workflows/gitleaks.yml
+++ b/templates/go-lib/.github/workflows/gitleaks.yml
@@ -14,3 +14,5 @@ jobs:
     permissions:
       contents: read
       security-events: write
+    secrets:
+      GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}


### PR DESCRIPTION
## Summary

With the caller-permissions fix in #64 the Gitleaks workflow now starts, but the scan itself now fails fleet-wide with:

\`\`\`
[netresearch] is an organization. License key is required.
\`\`\`

\`gitleaks-action@v2\` requires a commercial license key for org-hosted repos. The org already has \`GITLEAKS_LICENSE\` configured as an org secret, and the reusable workflow declares it as an optional \`workflow_call\` secret — but the caller templates weren't forwarding it, so the reusable never saw a value.

Forward the secret explicitly (no \`secrets: inherit\` — per CLAUDE.md org policy of minimizing blast radius of org secrets passing through reusable workflows).

## Test plan

- [x] YAML parses.
- [ ] After merge + template sync to all 6 consumers, the next main push must show Gitleaks passing (not the license-error failure).