### PR TITLE
fix(go-app/release): auto-detect main package (root or cmd/<name>)

### DIFF
--- a/templates/go-app/.github/workflows/release.yml
+++ b/templates/go-app/.github/workflows/release.yml
@@ -62,6 +62,9 @@ jobs:
       attestations: write
     with:
       binary-name: ${{ github.event.repository.name }}-${{ matrix.target }}
+      # Fleet convention: main package lives at `./main.go` (repo root) OR
+      # `./cmd/<repo-name>/main.go`. Any other layout is non-conforming.
+      main-package: ${{ hashFiles(format('cmd/{0}/main.go', github.event.repository.name)) != '' && format('./cmd/{0}', github.event.repository.name) || '.' }}
       goos: ${{ matrix.goos }}
       goarch: ${{ matrix.goarch }}
       goarm: ${{ matrix.goarm || '' }}


### PR DESCRIPTION
The template hardcoded main-package to build-go-attest.yml's default (`.`), which works for repos with main.go at root (ofelia, raybeam, ldap-ssp). ldap-manager has its main at `./cmd/ldap-manager` and would fail to build.

Use a hashFiles() expression to pick `./cmd/<repo-name>` when its main.go exists, otherwise fall back to `.`. Keeps the file byte-identical across consumers.