### PR TITLE
fix(go-app/release): drop broken hashFiles guard on setup-bun

### DIFF
--- a/templates/go-app/.github/workflows/release.yml
+++ b/templates/go-app/.github/workflows/release.yml
@@ -72,7 +72,13 @@ jobs:
       ref: ${{ needs.create-release.outputs.tag }}
       release-tag: ${{ needs.create-release.outputs.tag }}
       sbom: true
-      setup-bun: ${{ hashFiles('package.json') != '' }}
+      # setup-bun runs unconditionally. `hashFiles()` in the caller's `with:`
+      # is evaluated BEFORE the reusable workflow's checkout, so the caller
+      # workspace is empty and any guard would have always returned false.
+      # The bun install/run commands below are `-f package.json`-gated, so
+      # non-frontend repos (ofelia, raybeam) pay only the ~10s Bun install
+      # overhead per matrix entry — no actual bun work happens.
+      setup-bun: true
       pre-build-command: |
         if [ -f package.json ]; then
           bun install --frozen-lockfile


### PR DESCRIPTION
Addresses Copilot review on [#66](https://github.com/netresearch/.github/pull/66). The `hashFiles('package.json')` expression gating `setup-bun` is evaluated in the caller context BEFORE the reusable workflow's checkout. At that point the caller workspace is empty, so the guard always returned false — including for ldap-manager and ldap-ssp that genuinely need Bun.

Drop the guard (`setup-bun: true` unconditionally). The `bun install` / `bun run build:assets` commands inside `pre-build-command` are still `-f package.json`-gated, so non-frontend repos (ofelia, raybeam) pay only the ~10s Bun install overhead per matrix entry and skip the bun work.