### PR TITLE
feat(build-go-attest): main-package: auto (root or cmd/<repo-name>)

### DIFF
--- a/.github/workflows/build-go-attest.yml
+++ b/.github/workflows/build-go-attest.yml
@@ -31,7 +31,12 @@ on:
         type: string
         default: "go.mod"
       main-package:
-        description: "Go main package path"
+        description: >-
+          Go main package path. Set to `auto` to resolve after checkout:
+          if `./main.go` exists it uses `.`, otherwise if
+          `./cmd/<repo-name>/main.go` exists it uses `./cmd/<repo-name>`,
+          otherwise the build step fails. Accepts any explicit path
+          (e.g. `./cmd/cli`) to bypass the auto-detection.
         required: false
         type: string
         default: "."
@@ -174,9 +179,23 @@ jobs:
           BINARY_NAME: ${{ inputs.binary-name }}
           LDFLAGS: ${{ inputs.ldflags }}
           MAIN_PACKAGE: ${{ inputs.main-package }}
+          REPO_NAME: ${{ github.event.repository.name }}
           INPUT_GOARM: ${{ inputs.goarm }}
         run: |
           set -euo pipefail
+
+          # Resolve `main-package: auto` against the checked-out tree.
+          if [[ "${MAIN_PACKAGE}" == "auto" ]]; then
+            if [[ -f "./main.go" ]]; then
+              MAIN_PACKAGE="."
+            elif [[ -f "./cmd/${REPO_NAME}/main.go" ]]; then
+              MAIN_PACKAGE="./cmd/${REPO_NAME}"
+            else
+              echo "::error::main-package=auto: neither ./main.go nor ./cmd/${REPO_NAME}/main.go exists. Set main-package explicitly." >&2
+              exit 1
+            fi
+            echo "main-package auto-detected as ${MAIN_PACKAGE}"
+          fi
 
           # Only set GOARM when building for ARM architecture
           if [[ "${GOARCH}" == "arm" ]]; then

--- a/templates/go-app/.github/workflows/release.yml
+++ b/templates/go-app/.github/workflows/release.yml
@@ -62,9 +62,12 @@ jobs:
       attestations: write
     with:
       binary-name: ${{ github.event.repository.name }}-${{ matrix.target }}
-      # Fleet convention: main package lives at `./main.go` (repo root).
-      # build-go-attest.yml defaults main-package to `.`, so no input is
-      # needed. All 4 go-app consumers satisfy this convention.
+      # Resolve after checkout (see build-go-attest.yml). `auto` picks
+      # `.` when ./main.go exists, else `./cmd/<repo-name>` when that
+      # main.go exists, else fails. Keeps this template file byte-
+      # identical regardless of whether the consumer uses a root-main
+      # or cmd/ layout.
+      main-package: auto
       goos: ${{ matrix.goos }}
       goarch: ${{ matrix.goarch }}
       goarm: ${{ matrix.goarm || '' }}


### PR DESCRIPTION
Adds an `auto` value for the `main-package` input in `build-go-attest.yml`. When set, the build step resolves it after checkout:

- `./main.go` exists → `MAIN_PACKAGE="."`
- `./cmd/$REPO_NAME/main.go` exists → `MAIN_PACKAGE="./cmd/$REPO_NAME"`
- otherwise → step fails with a clear message

The go-app `release.yml` template now passes `main-package: auto`, so the workflow file stays byte-identical across consumers regardless of layout:
- ofelia, raybeam, ldap-ssp → root-main → resolves to `.`
- ldap-manager → `cmd/ldap-manager/main.go` → resolves to `./cmd/ldap-manager`

Replaces the actionlint-rejected `hashFiles(format(...))` expression from #67 — `hashFiles()` isn't allowed in top-level `with:` expressions, only in step-level ones. Moving the detection into the reusable workflow (where checkout has happened) is both correct and composable.

## Test plan

- [x] actionlint clean.
- [ ] Next tagged release on each go-app consumer resolves main-package correctly.