### PR TITLE
fix(build-go-attest): eliminate remaining SIGPIPE race in has_main

### DIFF
--- a/.github/workflows/build-go-attest.yml
+++ b/.github/workflows/build-go-attest.yml
@@ -197,13 +197,16 @@ jobs:
             REPO_NAME="${GITHUB_REPOSITORY##*/}"
 
             # has_main <dir> — succeeds iff <dir>/*.go (excluding *_test.go)
-            # contains a `package main` declaration. Uses find instead of
-            # a grep pipeline to avoid SIGPIPE races under `set -o pipefail`.
+            # contains a `package main` declaration. Collects the grep
+            # output into a variable instead of piping through a reader
+            # that could exit early — eliminates any SIGPIPE race under
+            # `set -o pipefail` regardless of how many files match.
             has_main() {
               local dir="$1"
-              find "$dir" -maxdepth 1 -type f -name '*.go' ! -name '*_test.go' \
-                -exec grep -qE '^package main([[:space:]]|$)' {} \; -print 2>/dev/null \
-                | grep -q .
+              local matches
+              matches=$(find "$dir" -maxdepth 1 -type f -name '*.go' ! -name '*_test.go' \
+                -exec grep -lE '^package main([[:space:]]|$)' {} + 2>/dev/null)
+              [[ -n "$matches" ]]
             }
 
             if has_main .; then


### PR DESCRIPTION
Copilot review on [#72](https://github.com/netresearch/.github/pull/72) caught that `| grep -q .` exits after the first line, so when `find ... -exec ... -print` has more than one matching file the producer can hit SIGPIPE. Under `set -o pipefail` that turns into a non-zero status and the detection silently fails — even though a match exists.

Swap the pipe for a variable-capture. `find`'s output goes directly into a local via command substitution, then `[[ -n $matches ]]` tests it. No reader, no pipe, no SIGPIPE regardless of match count.

Verified locally with 3 package-main files in the same directory — detection succeeds.