### PR TITLE
feat(go-app/release): inject main.buildTime ldflag

### DIFF
--- a/templates/go-app/.github/workflows/release.yml
+++ b/templates/go-app/.github/workflows/release.yml
@@ -71,7 +71,17 @@ jobs:
       goos: ${{ matrix.goos }}
       goarch: ${{ matrix.goarch }}
       goarm: ${{ matrix.goarm || '' }}
-      ldflags: "-s -w -X main.version=${{ needs.create-release.outputs.tag }} -X main.build=${{ needs.create-release.outputs.sha }}"
+      # Fleet ldflag convention: repos that want to surface release
+      # metadata declare `var version, build, buildTime string` in their
+      # main package. Each repo decides which to forward into its own
+      # version package (ofelia uses main.* directly; ldap-manager
+      # forwards into internal/version.*). Empty values are a silent
+      # no-op for repos that don't declare the corresponding var.
+      ldflags: >-
+        -s -w
+        -X main.version=${{ needs.create-release.outputs.tag }}
+        -X main.build=${{ needs.create-release.outputs.sha }}
+        -X main.buildTime=${{ github.event.head_commit.timestamp }}
       ref: ${{ needs.create-release.outputs.tag }}
       release-tag: ${{ needs.create-release.outputs.tag }}
       sbom: true


### PR DESCRIPTION
Copilot review on [ldap-manager#561](https://github.com/netresearch/ldap-manager/pull/561) noted that `internal/version.BuildTimestamp` stays `"n/a"` in release builds because the template only injects `main.version` + `main.build`.

Extend the ldflags with `-X main.buildTime=${{ github.event.head_commit.timestamp }}` so repos that declare `var buildTime string` in package main can surface the commit timestamp. Repos that don't declare the var pay a silent no-op.

Empty when `github.event.head_commit` is unavailable (e.g. some `workflow_dispatch` backfills); empty is harmless — consumers test `if buildTime != ""` before forwarding.