### PR TITLE
feat(build-go-attest): auto-build-timestamp input (closes #76)

### DIFF
--- a/.github/workflows/build-go-attest.yml
+++ b/.github/workflows/build-go-attest.yml
@@ -100,6 +100,19 @@ on:
         required: false
         type: string
         default: ""
+      auto-build-timestamp:
+        description: >-
+          When true, resolve the HEAD commit timestamp (ISO-8601, via
+          `git show -s --format=%cI`) after checkout and append
+          `-X main.buildTime=<value>` to ldflags. Works for every
+          trigger — including `workflow_dispatch` backfills where
+          `github.event.head_commit` is absent — because the timestamp
+          comes from the checked-out git tree, not the event payload.
+          Requires the consumer's main package to declare
+          `var buildTime string` (empty string if not consumed).
+        required: false
+        type: boolean
+        default: false
 
 # CALLER REQUIREMENTS
 # ===================
@@ -185,8 +198,26 @@ jobs:
           LDFLAGS: ${{ inputs.ldflags }}
           MAIN_PACKAGE: ${{ inputs.main-package }}
           INPUT_GOARM: ${{ inputs.goarm }}
+          AUTO_BUILD_TIMESTAMP: ${{ inputs.auto-build-timestamp }}
         run: |
           set -euo pipefail
+
+          # Resolve HEAD commit's ISO-8601 timestamp into an appended
+          # `-X main.buildTime=<value>` ldflag when the caller opted in.
+          # Works on every trigger because it reads git directly instead
+          # of `github.event.head_commit.timestamp` (empty on
+          # workflow_dispatch backfills). Requires the consumer's main
+          # package to declare `var buildTime string`; the ldflag is a
+          # silent no-op otherwise.
+          if [[ "${AUTO_BUILD_TIMESTAMP}" == "true" ]]; then
+            BUILD_TS=$(git show -s --format=%cI HEAD 2>/dev/null || true)
+            if [[ -n "${BUILD_TS}" ]]; then
+              LDFLAGS="${LDFLAGS} -X main.buildTime=${BUILD_TS}"
+              echo "auto-build-timestamp: appended -X main.buildTime=${BUILD_TS}"
+            else
+              echo "::warning::auto-build-timestamp=true but 'git show' produced no value; main.buildTime left unset."
+            fi
+          fi
 
           # Resolve `main-package: auto` against the checked-out tree.
           # Locates a `package main` declaration in any non-test *.go

--- a/templates/go-app/.github/workflows/release.yml
+++ b/templates/go-app/.github/workflows/release.yml
@@ -77,11 +77,14 @@ jobs:
       # version package (ofelia uses main.* directly; ldap-manager
       # forwards into internal/version.*). Empty values are a silent
       # no-op for repos that don't declare the corresponding var.
+      # main.buildTime is injected via auto-build-timestamp (below)
+      # so it stays populated on workflow_dispatch backfills where
+      # github.event.head_commit is absent.
       ldflags: >-
         -s -w
         -X main.version=${{ needs.create-release.outputs.tag }}
         -X main.build=${{ needs.create-release.outputs.sha }}
-        -X main.buildTime=${{ github.event.head_commit.timestamp }}
+      auto-build-timestamp: true
       ref: ${{ needs.create-release.outputs.tag }}
       release-tag: ${{ needs.create-release.outputs.tag }}
       sbom: true


### PR DESCRIPTION
Resolves [#76](https://github.com/netresearch/.github/issues/76). Copilot on [ldap-ssp#568](https://github.com/netresearch/ldap-selfservice-password-changer/pull/568) flagged that `github.event.head_commit.timestamp` is empty on `workflow_dispatch` events (the 'Tag to (re)build' backfill path), so manual re-releases baked `main.buildTime=` (empty) into the binary.

## Fix

Move resolution into `build-go-attest.yml` where the checkout has already happened:

- **New input `auto-build-timestamp`** (bool, default false). When true, resolve the HEAD commit's ISO-8601 timestamp via `git show -s --format=%cI HEAD` and append `-X main.buildTime=<value>` to the ldflags string just before `go build`. No reliance on the event payload, so tag pushes and workflow_dispatch backfills behave identically.
- **Template go-app `release.yml`** drops the baked `-X main.buildTime=${{ github.event.head_commit.timestamp }}` and passes `auto-build-timestamp: true` instead. Consumers resync to pick up the one-line change.

Silent no-op for repos that don't declare `var buildTime string` in package main (modern Go linkers ignore `-X` targets for missing vars).

## Test plan

- [x] actionlint clean on both files.
- [ ] Next tagged release on each consumer logs a real ISO-8601 `build_time`.
- [ ] Follow-up: `gh workflow run Release -f tag=vX.Y.Z` (workflow_dispatch) produces the same timestamp, not an empty string.