### PR TITLE
fix(build-go-attest): unmerge git show stderr from BUILD_TS

### DIFF
--- a/.github/workflows/build-go-attest.yml
+++ b/.github/workflows/build-go-attest.yml
@@ -217,12 +217,15 @@ jobs:
           # fails hard if resolution yields an empty string so opting in
           # can't silently ship a binary with an empty buildTime.
           if [[ "${AUTO_BUILD_TIMESTAMP}" == "true" ]]; then
-            # Capture both success/failure explicitly — `set -e` would
-            # otherwise abort on a non-zero `git show` before the custom
-            # diagnostic runs. The empty-string check still fires for
-            # exit-0-empty-output edge cases.
-            if ! BUILD_TS=$(git show -s --format=%cI HEAD 2>&1); then
-              echo "::error::auto-build-timestamp=true but 'git show -s --format=%cI HEAD' failed: ${BUILD_TS}. Check that actions/checkout completed and HEAD points at a real commit."
+            # Capture success/failure explicitly — `set -e` would otherwise
+            # abort on a non-zero `git show` before the custom diagnostic
+            # runs. Stderr intentionally NOT merged into BUILD_TS so a
+            # warning on stderr (exit 0) can't corrupt the ldflag value;
+            # git's own error message still surfaces through the Actions
+            # step log naturally. The empty-string check still fires for
+            # the exit-0-empty-stdout edge case.
+            if ! BUILD_TS=$(git show -s --format=%cI HEAD); then
+              echo "::error::auto-build-timestamp=true but 'git show -s --format=%cI HEAD' failed. See the git error above. Check that actions/checkout completed and HEAD points at a real commit."
               exit 1
             fi
             if [[ -z "${BUILD_TS}" ]]; then


### PR DESCRIPTION
Copilot on [#79](https://github.com/netresearch/.github/pull/79): merging stderr into stdout via `2>&1` meant that if `git show` exited 0 with a warning on stderr, `BUILD_TS` would contain that warning text — the empty-string check would still pass, and the ldflag would assemble with a non-timestamp value, breaking `go build` or shipping corrupted metadata.

Drop the merge. `BUILD_TS` captures stdout only; git's stderr flows to the Actions step log naturally. The `::error::` annotation points users at 'the git error above' instead of inlining a potentially corrupted string.