### PR TITLE
fix(go-lib): remove npm and devcontainers dependabot ecosystems

### DIFF
--- a/templates/go-lib/.github/dependabot.yml
+++ b/templates/go-lib/.github/dependabot.yml
@@ -29,23 +29,3 @@ updates:
     groups:
       docker:
         patterns: ['*']
-
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: weekly
-      day: monday
-    open-pull-requests-limit: 5
-    groups:
-      npm:
-        patterns: ['*']
-
-  - package-ecosystem: devcontainers
-    directory: /
-    schedule:
-      interval: weekly
-      day: monday
-    open-pull-requests-limit: 2
-    groups:
-      devcontainers:
-        patterns: ['*']


### PR DESCRIPTION
## Summary

The `go-lib` template's `.github/dependabot.yml` declares `npm` and `devcontainers` ecosystems, but Go libraries generally ship neither a `package.json` nor a `.devcontainer/` directory. Dependabot's weekly update job fails with:

    dependency_file_not_found: /package.json not found

turning main red on every consumer repo that syncs this template.

- **Kept**: `gomod`, `github-actions`, `docker` (docker is a silent no-op when the repo has no Dockerfile)
- **Removed**: `npm`, `devcontainers` (both error when their manifests are missing)

## Scope

- `templates/go-lib/.github/dependabot.yml` only
- go-app template left untouched (go-apps DO ship package.json for frontend assets and can have Dockerfile/devcontainer)

## Test plan

- [x] First observed failure: https://github.com/netresearch/simple-ldap-go/actions/runs/24687875276 (`Dependabot / npm` → `dependency_file_not_found: /package.json not found`)
- Matching consumer-side PR: netresearch/simple-ldap-go#159 (brings the repo in line with the new template shape)
- After both merge, simple-ldap-go's weekly Dependabot run should succeed (verifiable on the next Monday schedule or by triggering a manual run)