### PR TITLE
fix(ghcr-retention): iterate tags+patterns correctly in jq any()

### DIFF
--- a/.github/workflows/ghcr-retention.yml
+++ b/.github/workflows/ghcr-retention.yml
@@ -167,7 +167,7 @@ jobs:
               # Check if ANY tag matches a release pattern (kept forever)
               HAS_RELEASE_TAG=$(echo "$version" | jq -r --argjson patterns "$RELEASE_REGEX_JSON" '
                 .metadata.container.tags // []
-                | any(.; . as $t | $patterns | any(.; $t | test(.)))
+                | any(.[]; . as $t | any($patterns[]; . as $p | $t | test($p)))
               ')
 
               if [ "$HAS_RELEASE_TAG" = "true" ]; then
@@ -177,7 +177,7 @@ jobs:
               # Check if this is an edge-pattern image
               IS_EDGE=$(echo "$version" | jq -r --argjson patterns "$EDGE_REGEX_JSON" '
                 .metadata.container.tags // []
-                | any(.; . as $t | $patterns | any(.; $t | test(.)))
+                | any(.[]; . as $t | any($patterns[]; . as $p | $t | test($p)))
               ')
 
               if [ "$IS_EDGE" != "true" ]; then


### PR DESCRIPTION
## Summary

The GHCR retention workflow fails on every non-empty page of results:

\`\`\`
jq: error (at <stdin>:1): array (["pr-540"]) cannot be matched, as it is not a string
##[error]Process completed with exit code 5.
\`\`\`

Two bugs in the same \`any()\` expression:

1. \`any(.; …)\` — first argument must be a filter that PRODUCES a stream. Passing \`.\` runs the condition once with \`.\` bound to the whole tags array, and the condition then tries \`test(...)\` on an array → runtime error.
2. \`\$t | test(.)\` — after the pipe \`.\` is bound to \`\$t\`, so \`test(.)\` ends up testing \`\$t\` against itself as a regex. Non-empty strings match themselves → silent false positives even after bug #1 is fixed.

## Fix

\`\`\`jq
any(.[]; . as \$t | any(\$patterns[]; . as \$p | \$t | test(\$p)))
\`\`\`

- \`.[]\` streams each tag to the outer \`any\`
- \`\$patterns[]\` streams each regex pattern to the inner \`any\`
- \`. as \$p\` captures the pattern, then \`\$t | test(\$p)\` runs the regex correctly against the tag

## Verification

Local four-case table × two pattern sets, all four outcomes match intent:

| tags | release pattern \`[v*, latest*]\` | edge pattern \`[edge*]\` |
|---|---|---|
| \`[pr-540]\` | false (expected: false) ✓ | false (expected: false) ✓ |
| \`[v1.12.0, latest]\` | true ✓ | false ✓ |
| \`[edge-main]\` | false ✓ | true ✓ |
| \`[]\` | false ✓ | false ✓ |

Root-caused from a failing retention dry-run on \`netresearch/ldap-manager\` ([run 24875603232](https://github.com/netresearch/ldap-manager/actions/runs/24875603232)). Retention had never successfully executed on any consumer repo because the workflow was only added last week and the weekly schedule hasn't fired yet.

## Test plan

- [ ] Existing consumers trigger their Container Retention workflow manually with \`dry-run: true\` after this lands, observe summary ("N edge versions to delete") instead of exit 5