### PR TITLE
fix(ghcr-retention): pin crane to existing release (v0.22.1 → v0.21.5)

### DIFF
--- a/.github/workflows/ghcr-retention.yml
+++ b/.github/workflows/ghcr-retention.yml
@@ -249,7 +249,7 @@ jobs:
         with:
           # Pin crane to a known-good release; `latest` broke CI in the past
           # when upstream re-tagged without backward compat.
-          version: v0.22.1
+          version: v0.21.5
 
       - name: Log in to Container registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0


### PR DESCRIPTION
## Summary

`setup-crane` is pinned to `v0.22.1`, which does not exist on google/go-containerregistry — the latest tagged release is `v0.21.5` (2026-04-11). Every orphan-cleanup job fails during install with:

```
curl: (22) The requested URL returned error: 404
```

against `https://github.com/google/go-containerregistry/releases/download/v0.22.1/go-containerregistry_Linux_x86_64.tar.gz` (× 6 retries per the curl `--retry 5 --retry-all-errors` flags).

Observed second-in-a-row on `netresearch/ldap-manager` retention ([run 24875833349](https://github.com/netresearch/ldap-manager/actions/runs/24875833349)) after PR #87 unblocked the first step. This is the immediate successor failure.

## Fix

Change `version: v0.22.1` → `version: v0.21.5`. Asset name (`go-containerregistry_Linux_x86_64.tar.gz`) is unchanged, so `setup-crane`'s inner fetch needs no other adjustment.

## Longer term

The code comment says *"Pin crane to a known-good release; `latest` broke CI in the past when upstream re-tagged without backward compat."* — but pinning to a non-existent version is strictly worse. Worth revisiting with `latest` + smoke test, or automating version bumps via Renovate so we catch yanked versions at PR time instead of the weekly cron.

## Test plan

- [ ] Run Container Retention on `netresearch/ldap-manager` manually with `dry-run: true` after this lands; orphan job must reach "Processing page 1..." instead of failing at `curl` install