### PR TITLE
fix(ghcr-retention): log API error body on delete failure

### DIFF
--- a/.github/workflows/ghcr-retention.yml
+++ b/.github/workflows/ghcr-retention.yml
@@ -214,14 +214,21 @@ jobs:
           FAILED=0
           for VERSION_ID in "${VERSIONS_TO_DELETE[@]}"; do
             echo "Deleting version ${VERSION_ID}..."
-            if gh api \
+            if DELETE_OUT=$(gh api \
               --method DELETE \
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              "/orgs/${OWNER}/packages/container/${PACKAGE_NAME}/versions/${VERSION_ID}" 2>/dev/null; then
+              "/orgs/${OWNER}/packages/container/${PACKAGE_NAME}/versions/${VERSION_ID}" 2>&1); then
               DELETED=$((DELETED + 1))
             else
-              echo "  WARNING: Failed to delete version ${VERSION_ID}"
+              # Capture the API error body so operators can see WHY the
+              # delete was refused (common causes: 404 for race-deleted
+              # siblings, 422 for versions still referenced by an OCI
+              # manifest crane didn't traverse, 403 for package-level
+              # delete restrictions). The body goes on a single line
+              # so one-liner log scans keep working.
+              ERR_ONE_LINE=$(echo "$DELETE_OUT" | tr '\n' ' ' | head -c 400)
+              echo "  WARNING: Failed to delete version ${VERSION_ID}: ${ERR_ONE_LINE}"
               FAILED=$((FAILED + 1))
             fi
           done
@@ -386,14 +393,21 @@ jobs:
           FAILED=0
           for VERSION_ID in "${VERSIONS_TO_DELETE[@]}"; do
             echo "Deleting version ${VERSION_ID}..."
-            if gh api \
+            if DELETE_OUT=$(gh api \
               --method DELETE \
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              "/orgs/${OWNER}/packages/container/${PACKAGE_NAME}/versions/${VERSION_ID}" 2>/dev/null; then
+              "/orgs/${OWNER}/packages/container/${PACKAGE_NAME}/versions/${VERSION_ID}" 2>&1); then
               DELETED=$((DELETED + 1))
             else
-              echo "  WARNING: Failed to delete version ${VERSION_ID}"
+              # Capture the API error body so operators can see WHY the
+              # delete was refused (common causes: 404 for race-deleted
+              # siblings, 422 for versions still referenced by an OCI
+              # manifest crane didn't traverse, 403 for package-level
+              # delete restrictions). The body goes on a single line
+              # so one-liner log scans keep working.
+              ERR_ONE_LINE=$(echo "$DELETE_OUT" | tr '\n' ' ' | head -c 400)
+              echo "  WARNING: Failed to delete version ${VERSION_ID}: ${ERR_ONE_LINE}"
               FAILED=$((FAILED + 1))
             fi
           done


### PR DESCRIPTION
## Summary

The two delete loops ran:

\`\`\`bash
if gh api --method DELETE ... 2>/dev/null; then
  DELETED=$((DELETED + 1))
else
  echo "  WARNING: Failed to delete version ${VERSION_ID}"
  ...
fi
\`\`\`

With `2>/dev/null` the real API error body was discarded and operators got only a bare \"WARNING\" line. Observed on netresearch/ldap-manager retention [run 24879934330](https://github.com/netresearch/ldap-manager/actions/runs/24879934330): 4,839 deletes succeeded, 82 failed — all from the first two weeks after the package was created in Oct 2023. Without the response body it's not diagnosable.

## Fix

\`\`\`bash
if DELETE_OUT=$(gh api --method DELETE ... 2>&1); then
  DELETED=$((DELETED + 1))
else
  ERR_ONE_LINE=$(echo "$DELETE_OUT" | tr '\n' ' ' | head -c 400)
  echo "  WARNING: Failed to delete version ${VERSION_ID}: ${ERR_ONE_LINE}"
  ...
fi
\`\`\`

Applied to both delete sites (edge cleanup + orphan cleanup). Truncate at 400 chars so one-line log scans keep working.

## Test plan

- [ ] Re-run Container Retention on netresearch/ldap-manager with \`dry-run: false\` after this lands; the 82 still-failing versions should each emit a per-version HTTP status + message (404 / 422 / 403) instead of a bare WARNING