### PR TITLE
fix(ghcr-retention): fail loud on API fetch error

### DIFF
--- a/.github/workflows/ghcr-retention.yml
+++ b/.github/workflows/ghcr-retention.yml
@@ -139,10 +139,20 @@ jobs:
           VERSIONS_TO_DELETE=()
 
           while true; do
-            VERSIONS=$(gh api \
+            # Fail loudly if the API call errors — previously the
+            # `2>/dev/null || echo "[]"` pattern concatenated the
+            # error body onto the fallback `[]`, producing TWO JSON
+            # documents in $VERSIONS. `jq 'length'` then returned
+            # multiline output (e.g. "3\n0" for an error object
+            # followed by the empty array) and every downstream
+            # bash test / jq pipeline mangled.
+            if ! VERSIONS=$(gh api \
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              "/orgs/${OWNER}/packages/container/${PACKAGE_NAME}/versions?per_page=100&page=${PAGE}" 2>/dev/null || echo "[]")
+              "/orgs/${OWNER}/packages/container/${PACKAGE_NAME}/versions?per_page=100&page=${PAGE}" 2>&1); then
+              echo "::error::Failed to fetch versions page ${PAGE}: $(echo "$VERSIONS" | tr '\n' ' ' | head -c 400)"
+              exit 1
+            fi
 
             # Check if we got any versions
             COUNT=$(echo "$VERSIONS" | jq 'length')
@@ -329,10 +339,20 @@ jobs:
           VERSIONS_TO_DELETE=()
 
           while true; do
-            VERSIONS=$(gh api \
+            # Fail loudly if the API call errors — previously the
+            # `2>/dev/null || echo "[]"` pattern concatenated the
+            # error body onto the fallback `[]`, producing TWO JSON
+            # documents in $VERSIONS. `jq 'length'` then returned
+            # multiline output (e.g. "3\n0" for an error object
+            # followed by the empty array) and every downstream
+            # bash test / jq pipeline mangled.
+            if ! VERSIONS=$(gh api \
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
-              "/orgs/${OWNER}/packages/container/${PACKAGE_NAME}/versions?per_page=100&page=${PAGE}" 2>/dev/null || echo "[]")
+              "/orgs/${OWNER}/packages/container/${PACKAGE_NAME}/versions?per_page=100&page=${PAGE}" 2>&1); then
+              echo "::error::Failed to fetch versions page ${PAGE}: $(echo "$VERSIONS" | tr '\n' ' ' | head -c 400)"
+              exit 1
+            fi
 
             COUNT=$(echo "$VERSIONS" | jq 'length')
             if [ "$COUNT" -eq 0 ]; then


### PR DESCRIPTION
## Summary

Paginated fetch used \`VERSIONS=\$(gh api ... 2>/dev/null || echo \"[]\")\` which swallows API errors and concatenates the response body onto the fallback \`[]\`. Two JSON documents land in \`\$VERSIONS\`, and every downstream jq/bash pipeline corrupts:

\`\`\`
Processing page 1 (3
0 versions)...
0: integer expression expected
jq: error (at <stdin>:1): Cannot index string with string \"id\"
\`\`\`

Observed on netresearch/ldap-manager after the large retention run ([24879934330](https://github.com/netresearch/ldap-manager/actions/runs/24879934330)) used up primary API quota. Subsequent runs ([24881997881](https://github.com/netresearch/ldap-manager/actions/runs/24881997881), [24882158006](https://github.com/netresearch/ldap-manager/actions/runs/24882158006)) hit the rate limit, got an error response, and corrupted.

## Fix

\`\`\`bash
if ! VERSIONS=\$(gh api ... 2>&1); then
  echo \"::error::Failed to fetch versions page \${PAGE}: \$(echo \"\$VERSIONS\" | tr '\\n' ' ' | head -c 400)\"
  exit 1
fi
\`\`\`

Applied to both fetch loops (edge + orphan). No silent corruption; operator sees the real cause immediately via GitHub Actions \`::error::\` annotation.

## Test plan

- [ ] Trigger retention when rate-limited (or with invalid scope); workflow must annotate the \`::error::\` with the real response body instead of silently breaking later