### PR TITLE
fix(release): support draft-then-publish lifecycle (immutable releases)

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -243,12 +243,23 @@ jobs:
         run: |
           set -euo pipefail
 
+          # GitHub forbids drafts (and prereleases) from being marked
+          # as 'latest' — `gh release create --latest=true --draft`
+          # errors. When creating as draft, force --latest=false here;
+          # the finalize-release workflow's publish step flips draft to
+          # published with the correct --latest flag.
+          if [ "$DRAFT" = "true" ]; then
+            EFFECTIVE_LATEST=false
+          else
+            EFFECTIVE_LATEST="$MAKE_LATEST"
+          fi
+
           if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
             echo "Release $TAG already exists — updating"
-            gh release edit "$TAG" --repo "$REPO" --notes "$NOTES" --latest="$MAKE_LATEST" --prerelease="$IS_PRE" --draft="$DRAFT"
+            gh release edit "$TAG" --repo "$REPO" --notes "$NOTES" --latest="$EFFECTIVE_LATEST" --prerelease="$IS_PRE" --draft="$DRAFT"
           else
             echo "Creating new release $TAG"
-            CREATE_ARGS=("$TAG" "--repo" "$REPO" "--title" "$TAG" "--notes" "$NOTES" "--latest=$MAKE_LATEST")
+            CREATE_ARGS=("$TAG" "--repo" "$REPO" "--title" "$TAG" "--notes" "$NOTES" "--latest=$EFFECTIVE_LATEST")
             if [ "$IS_PRE" = "true" ]; then
               CREATE_ARGS+=("--prerelease")
             fi

--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -33,6 +33,16 @@ on:
         required: false
         type: string
         default: ""
+      make-latest:
+        description: "When publishing a draft release at the end of finalize, mark it as 'Latest'. No-op if the release is already published. Pass `needs.create-release.outputs.is-latest` from create-release."
+        required: false
+        type: string
+        default: "true"
+      prerelease:
+        description: "When publishing a draft release at the end of finalize, mark it as a prerelease. No-op if the release is already published. Pass `needs.create-release.outputs.is-prerelease` from create-release."
+        required: false
+        type: string
+        default: "false"
 
 # CALLER REQUIREMENTS
 # ===================
@@ -232,3 +242,31 @@ jobs:
           } > release_body.md
 
           gh release edit "$TAG" --repo "$REPO" --notes-file release_body.md
+
+      - name: Publish release (flip draft to published)
+        # Final step in the release lifecycle. When create-release was
+        # called with `draft: true` (the recommended pattern when
+        # downstream jobs upload assets — GitHub treats published
+        # releases as immutable and rejects asset uploads), this step
+        # flips the draft to published with the correct latest /
+        # prerelease flags. Idempotent: if the release is already
+        # published (e.g. caller didn't use draft mode), this is a
+        # no-op.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          REPO: ${{ github.repository }}
+          MAKE_LATEST: ${{ inputs.make-latest }}
+          PRERELEASE: ${{ inputs.prerelease }}
+        run: |
+          set -euo pipefail
+          IS_DRAFT=$(gh release view "$TAG" --repo "$REPO" --json isDraft --jq .isDraft)
+          if [ "$IS_DRAFT" != "true" ]; then
+            echo "Release $TAG is already published — skipping publish step"
+            exit 0
+          fi
+          echo "Publishing draft release $TAG (latest=$MAKE_LATEST, prerelease=$PRERELEASE)"
+          gh release edit "$TAG" --repo "$REPO" \
+            --draft=false \
+            --latest="$MAKE_LATEST" \
+            --prerelease="$PRERELEASE"

--- a/templates/go-app/.github/workflows/release.yml
+++ b/templates/go-app/.github/workflows/release.yml
@@ -39,6 +39,13 @@ jobs:
       contents: write
     with:
       tag: ${{ inputs.tag || github.ref_name }}
+      # Create as draft so downstream jobs (binaries, container,
+      # finalize) can upload assets. GitHub now treats published
+      # releases as immutable and rejects asset uploads after
+      # publication. The `finalize` job at the end of this pipeline
+      # publishes the draft with the correct latest / prerelease flags
+      # propagated from create-release outputs.
+      draft: true
 
   binaries:
     name: Build ${{ matrix.target }}
@@ -137,3 +144,8 @@ jobs:
     with:
       tag: ${{ needs.create-release.outputs.tag }}
       image-ref: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
+      # Propagate the latest / prerelease decision computed by
+      # create-release so the final publish step (inside finalize)
+      # flips the draft to published with the correct flags.
+      make-latest: ${{ needs.create-release.outputs.is-latest }}
+      prerelease: ${{ needs.create-release.outputs.is-prerelease }}


### PR DESCRIPTION
## Summary

GitHub now treats published releases as **immutable** — once a release is published, asset uploads return `HTTP 422: Cannot upload assets to an immutable release.`

The current go-app release pipeline (`create-release` → `binaries` → `container` → `finalize`) creates a published release in step 1, then every downstream job that uploads assets fails. Most recently observed on netresearch/ldap-manager [v1.4.0](https://github.com/netresearch/ldap-manager/releases/tag/v1.4.0): only the auto-generated source archives shipped — no binaries, no checksums, no SBOMs.

This PR introduces a **draft-then-publish** lifecycle:

1. `create-release` creates the release as a draft (when caller opts in via `draft: true`).
2. Downstream jobs upload assets to the draft (allowed).
3. `finalize-release` flips the draft to published with the correct `--latest` / `--prerelease` flags.

## Changes

### `.github/workflows/create-release.yml`
- When `draft: true`, force `--latest=false` at creation time. GitHub's API forbids drafts (and prereleases) from being marked as the latest release; passing `--latest=true --draft` errors out. The latest flag is set correctly when the draft is published by finalize.

### `.github/workflows/finalize-release.yml`
- Add `make-latest` and `prerelease` string inputs (defaults `"true"`/`"false"`).
- Add a final **Publish release** step that flips draft → published with the correct flags. **Idempotent**: skips when the release is already published.

### `templates/go-app/.github/workflows/release.yml`
- `create-release` now passes `draft: true`.
- `finalize` now forwards `make-latest: \${{ needs.create-release.outputs.is-latest }}` and `prerelease: \${{ needs.create-release.outputs.is-prerelease }}`.

## Backward compatibility

- **Simple callers** (those who only call `create-release.yml` and don't upload assets): unchanged. Default `draft` remains `false`.
- **Callers using `finalize-release.yml` without draft mode**: also unchanged. The new publish step detects the release is already published and exits 0.
- **Template consumers** (ldap-manager, ofelia, etc.): pick up the fix automatically via `check-template-drift` PRs.

## Limitation: backfills against already-published releases

The `workflow_dispatch` backfill flow on a tag whose release is already published (e.g. re-running v1.4.0's pipeline) cannot un-publish the release — GitHub doesn't allow that on published releases either. For backfills, delete the existing release first, or cut a new patch tag (e.g. v1.4.1).

## Test plan

- [ ] Merge this PR
- [ ] In a consumer repo (e.g. ldap-manager), accept the template-drift PR
- [ ] Cut a patch release (e.g. v1.4.1) and verify all binaries + checksums + SBOMs ship correctly
- [ ] Verify the release shows up under "Latest" with the correct flag