### PR TITLE
fix(gitleaks): switch shared workflow to betterleaks CLI (Node 24 compat)

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,4 +1,4 @@
-name: Gitleaks Secret Scanning
+name: Secret Scanning (betterleaks)
 
 on:
   workflow_call:
@@ -10,7 +10,9 @@ on:
         default: false
     secrets:
       GITLEAKS_LICENSE:
-        description: 'License key for Gitleaks'
+        # Accepted but ignored — kept for backwards compatibility with consumers
+        # that still pass it. betterleaks is fully OSS and needs no license.
+        description: 'Deprecated: no longer used (betterleaks needs no license). Accepted for backwards compatibility.'
         required: false
 
 permissions: {}
@@ -39,9 +41,32 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
+      - name: Install betterleaks
         env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+          BETTERLEAKS_VERSION: '1.1.2'
+          BETTERLEAKS_SHA256: '648c20617178065072ff1791d383192a62c911d9b4427f0426a8c504a6d9ddad'
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP"
+          curl -sSfL -o betterleaks.tar.gz \
+            "https://github.com/betterleaks/betterleaks/releases/download/v${BETTERLEAKS_VERSION}/betterleaks_${BETTERLEAKS_VERSION}_linux_x64.tar.gz"
+          echo "${BETTERLEAKS_SHA256}  betterleaks.tar.gz" | sha256sum -c -
+          tar -xzf betterleaks.tar.gz betterleaks
+          sudo install -m 0755 betterleaks /usr/local/bin/betterleaks
+          betterleaks version
+
+      - name: Run betterleaks
+        run: |
+          betterleaks git \
+            --redact \
+            --report-format sarif \
+            --report-path betterleaks.sarif \
+            --exit-code 2 \
+            "$GITHUB_WORKSPACE"
+
+      - name: Upload SARIF to code scanning
+        if: always() && hashFiles('betterleaks.sarif') != ''
+        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        with:
+          sarif_file: betterleaks.sarif
+          category: betterleaks


### PR DESCRIPTION
## Summary

`gitleaks-action@v2.3.9` is the latest pinned version. It's a Node 20 action that GitHub's runtime force-migrates to Node 24, breaking the action. The current workflow already sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`, but it doesn't help — runs still fail.

This PR replaces the `gitleaks-action` step with the [betterleaks](https://github.com/betterleaks/betterleaks) CLI (v1.1.2, released 2026-04-08), maintained by the original gitleaks author Zach Rice as a drop-in OSS successor.

## Why betterleaks (the CLI, not an action)

- Same author, same detection engine, fully OSS — no license needed.
- We invoke the binary directly via `curl` from the official GitHub release with a pinned version + SHA256 checksum (verified against [`checksums.txt`](https://github.com/betterleaks/betterleaks/releases/download/v1.1.2/checksums.txt)). No third-party action in the supply chain.
- A community `dortort/betterleaks-action` exists but has 0 stars; we skip it for trust + simplicity.

## What's preserved (no consumer break)

Consumer repos pin the required check context `gitleaks / Secret Scanning` in branch protection. To keep that intact:

- Workflow file path: `.github/workflows/gitleaks.yml` — unchanged
- Job ID: `gitleaks` — unchanged (forms the `gitleaks /` prefix)
- Job name: `Secret Scanning` — unchanged (forms the `/ Secret Scanning` suffix)
- `inputs.skip` — unchanged
- `secrets.GITLEAKS_LICENSE` — accepted but ignored (betterleaks needs no license); kept on the `workflow_call.secrets` declaration with `required: false` so callers passing it via `secrets:` don't error out

## What's changed (cosmetic)

- Top-level workflow `name:` → `Secret Scanning (betterleaks)` (clearer in the Actions UI; does NOT affect the required check context, which comes from the job, not the workflow)

## Implementation

- Install `betterleaks` v1.1.2 via curl from [the official release](https://github.com/betterleaks/betterleaks/releases/tag/v1.1.2), with SHA256 verification (`648c20617178065072ff1791d383192a62c911d9b4427f0426a8c504a6d9ddad` for `linux_x64`).
- Run `betterleaks git --redact --report-format sarif --report-path betterleaks.sarif --exit-code 2 "$GITHUB_WORKSPACE"`.
- Upload SARIF to GitHub code scanning via `github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7` (v4.35.3, latest pinned SHA), category `betterleaks`.

## Immediate consumer

Unblocks [`netresearch/enterprise-readiness-skill#68`](https://github.com/netresearch/enterprise-readiness-skill/pull/68) and all other consumer repos currently failing on `gitleaks-action` Node 24 incompatibility. Once merged to `@main`, those will pass on their next CI run.

## Test plan

- [ ] Self-hosted CI on this PR runs the new workflow against this repo (the `.github` repo references its own workflows).
- [ ] Verify the job context name on a check run is `gitleaks / Secret Scanning`.
- [ ] Spot-check one downstream consumer (`netresearch/enterprise-readiness-skill#68`) after merge to confirm the required check resolves.

## References

- [betterleaks v1.1.2 release](https://github.com/betterleaks/betterleaks/releases/tag/v1.1.2)
- [betterleaks repo + README](https://github.com/betterleaks/betterleaks)
- [gitleaks-action v2.3.9 (replaced)](https://github.com/gitleaks/gitleaks-action/releases/tag/v2.3.9)