### PR TITLE
fix(go-check): skip gosec SARIF upload on merge_group events

### DIFF
--- a/.github/workflows/go-check.yml
+++ b/.github/workflows/go-check.yml
@@ -453,7 +453,12 @@ jobs:
           args: "-no-fail -fmt sarif -out gosec-results.sarif ./..."
 
       - name: Upload gosec SARIF
-        if: always() && hashFiles('gosec-results.sarif') != ''
+        # Skip on merge_group: the gh-readonly-queue/<branch>/pr-NNN-<sha> ref is
+        # deleted by GitHub as soon as the merge completes, which races with
+        # codeql-action/upload-sarif and causes a guaranteed `ref ... not found`
+        # failure on every successful merge. Push and pull_request events
+        # re-run the same scan with a stable ref, so coverage is not lost.
+        if: always() && github.event_name != 'merge_group' && hashFiles('gosec-results.sarif') != ''
         uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
         with:
           sarif_file: gosec-results.sarif


### PR DESCRIPTION
## Summary

The `codeql-action/upload-sarif` step in the gosec job fails on **every** merge_group run because GitHub deletes the `gh-readonly-queue/<branch>/pr-NNN-<sha>` ref the moment the merge completes. By the time upload-sarif tries to attach results to that ref, it's gone:

```
##[error]ref 'refs/heads/gh-readonly-queue/main/pr-NNN-...' not found in this repository
```

This produces a guaranteed failure on every successful merge, which silently bypasses CI gating wherever branch protection treats merge_group results as non-required (e.g. netresearch/ofelia, where it allowed broken commits to land on main).

The push and pull_request events run the same scan against stable refs, so security coverage is not lost — only the redundant (and impossible) merge_group upload is skipped. Mirrors the existing job-level exclusion in `gitleaks.yml`.

Observed failures across recent merge_group runs in netresearch/ofelia:
- https://github.com/netresearch/ofelia/actions/runs/25430416774/job/74594899465
- https://github.com/netresearch/ofelia/actions/runs/25430330554
- https://github.com/netresearch/ofelia/actions/runs/25428744077
- https://github.com/netresearch/ofelia/actions/runs/25428286593
- https://github.com/netresearch/ofelia/actions/runs/25427886570

## Test plan

- [ ] Once merged, verify a fresh ofelia merge_group run no longer fails on `Upload gosec SARIF`
- [ ] Verify gosec SARIF still uploads from push/pull_request events (Security tab → Code scanning → gosec category)