### PR TITLE
fix: skip remaining SARIF uploads on merge_group events

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -195,7 +195,11 @@ jobs:
           scanners: "vuln,config,secret"
 
       - name: Upload Trivy results to GitHub Security
-        if: inputs.scan && inputs.push && hashFiles('trivy-results.sarif') != ''
+        # Skip on merge_group: the gh-readonly-queue ref is deleted by GitHub
+        # the moment the merge completes, racing with codeql-action/upload-sarif
+        # and producing a guaranteed `ref ... not found` failure. Push and
+        # release events run with stable refs.
+        if: inputs.scan && inputs.push && github.event_name != 'merge_group' && hashFiles('trivy-results.sarif') != ''
         uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
         with:
           sarif_file: "trivy-results.sarif"

--- a/.github/workflows/release-go-app.yml
+++ b/.github/workflows/release-go-app.yml
@@ -603,7 +603,11 @@ jobs:
           scanners: vuln,config,secret
 
       - name: Upload Trivy SARIF
-        if: hashFiles('trivy-results.sarif') != ''
+        # Skip on merge_group: the gh-readonly-queue ref is deleted by GitHub
+        # the moment the merge completes, racing with codeql-action/upload-sarif
+        # and producing a guaranteed `ref ... not found` failure. Release/push
+        # events run with stable refs.
+        if: github.event_name != 'merge_group' && hashFiles('trivy-results.sarif') != ''
         uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -34,6 +34,11 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF
+        # Skip on merge_group: the gh-readonly-queue ref is deleted by GitHub
+        # the moment the merge completes, racing with codeql-action/upload-sarif
+        # and producing a guaranteed `ref ... not found` failure. Push and
+        # schedule events run with stable refs.
+        if: github.event_name != 'merge_group'
         uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

Completes the same fix as #116 (gosec) for the three remaining reusable workflows that upload SARIF without a merge_group guard: \`build-container.yml\`, \`release-go-app.yml\`, \`scorecard.yml\`. The job-level guard already exists in \`gitleaks.yml\`.

When a workflow with a SARIF upload step is triggered by \`merge_group\`, \`codeql-action/upload-sarif\` fails 100% of the time because GitHub deletes the \`gh-readonly-queue/<branch>/pr-NNN-<sha>\` ref the moment the merge completes:

\`\`\`
##[error]ref 'refs/heads/gh-readonly-queue/...' not found in this repository
\`\`\`

Push, schedule, and release events run with stable refs, so security coverage is unchanged — only the impossible merge_group upload is skipped.

## Audit context

5 reusable workflows in this repo upload SARIF (\`grep -l upload-sarif .github/workflows/\`):

| Workflow | Status |
|---|---|
| \`gitleaks.yml\` | Already had job-level merge_group guard ✓ |
| \`go-check.yml\` (gosec step) | Fixed in #116 ✓ |
| \`build-container.yml\` | **Fixed here** |
| \`release-go-app.yml\` | **Fixed here** |
| \`scorecard.yml\` | **Fixed here** |

## Test plan

- [ ] Verify scorecard SARIF still uploads on push/schedule events (Security tab → Code scanning → scorecard)
- [ ] Verify trivy SARIF still uploads on release events (release-go-app.yml, build-container.yml)
- [ ] No callers regress on merge_group runs