### PR TITLE
feat(codeql): add pre-build-cmd input for code-generation steps

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,14 +31,25 @@ on:
           comma-separated list (e.g. `go,javascript-typescript`).
         type: string
         default: actions
-      pre-build-cmd:
+      pre-build-cmd-go:
         description: >-
-          Optional shell snippet executed after CodeQL init and before
-          `analyze` runs the autobuilder/extractor. Use for
-          code-generation steps whose outputs must exist for compiled
-          languages to extract cleanly — e.g. `templ generate`,
-          protobuf, OpenAPI clients. Runs under `bash -euo pipefail`.
-          Go is on PATH at this point because CodeQL init installs it.
+          Optional shell snippet executed for the Go matrix entry only,
+          after CodeQL init and before `analyze` runs the autobuilder.
+          Use for code-generation steps whose outputs must exist for the
+          Go extractor — e.g. `templ generate`, protobuf, OpenAPI
+          clients. Runs under `bash -euo pipefail`. Go is on PATH here
+          because CodeQL init installed it for this matrix entry.
+        type: string
+        default: ''
+      pre-build-cmd-javascript-typescript:
+        description: >-
+          Optional shell snippet executed for the JS/TS matrix entry
+          only, after CodeQL init and before `analyze`. Use for steps
+          like `bun install && bun run codegen` whose outputs must exist
+          for the JS/TS extractor. Runs under `bash -euo pipefail`.
+          Node.js / Bun are NOT installed automatically — add an
+          `actions/setup-node` step in the snippet if you need them, or
+          fork this workflow.
         type: string
         default: ''
 
@@ -125,10 +136,16 @@ jobs:
           languages: ${{ matrix.language }}
           queries: security-and-quality
 
-      - name: Run pre-build command
-        if: ${{ inputs.pre-build-cmd != '' }}
+      - name: Run Go pre-build command
+        if: ${{ matrix.language == 'go' && inputs.pre-build-cmd-go != '' }}
         env:
-          PRE_BUILD_CMD: ${{ inputs.pre-build-cmd }}
+          PRE_BUILD_CMD: ${{ inputs.pre-build-cmd-go }}
+        run: bash -euo pipefail -c "$PRE_BUILD_CMD"
+
+      - name: Run JS/TS pre-build command
+        if: ${{ matrix.language == 'javascript-typescript' && inputs.pre-build-cmd-javascript-typescript != '' }}
+        env:
+          PRE_BUILD_CMD: ${{ inputs.pre-build-cmd-javascript-typescript }}
         run: bash -euo pipefail -c "$PRE_BUILD_CMD"
 
       - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,6 +31,16 @@ on:
           comma-separated list (e.g. `go,javascript-typescript`).
         type: string
         default: actions
+      pre-build-cmd:
+        description: >-
+          Optional shell snippet executed after CodeQL init and before
+          `analyze` runs the autobuilder/extractor. Use for
+          code-generation steps whose outputs must exist for compiled
+          languages to extract cleanly — e.g. `templ generate`,
+          protobuf, OpenAPI clients. Runs under `bash -euo pipefail`.
+          Go is on PATH at this point because CodeQL init installs it.
+        type: string
+        default: ''
 
 permissions: {}
 
@@ -114,6 +124,12 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
+
+      - name: Run pre-build command
+        if: ${{ inputs.pre-build-cmd != '' }}
+        env:
+          PRE_BUILD_CMD: ${{ inputs.pre-build-cmd }}
+        run: bash -euo pipefail -c "$PRE_BUILD_CMD"
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3


### PR DESCRIPTION
## Summary

CodeQL's Go extraction runs an autobuilder (`go build ./...`). Repos that gitignore generated sources (`templ generate`, `protoc`, OpenAPI clients, etc.) hit extraction warnings like:

```
Warning: encountered errors extracting package github.com/.../internal/web/templates
```

The standalone `CodeQL` aggregator then returns `NEUTRAL` because no real analysis was produced. Branch rulesets with a `code_scanning` rule on `tool: CodeQL` interpret `NEUTRAL` as "still expecting" and block merge — even on PRs that didn't touch any Go.

Real example: [netresearch/ldap-manager#597](https://github.com/netresearch/ldap-manager/pull/597), which only changes `.github/workflows/*.yml` + `.gitleaksignore`, is BLOCKED with the message:

> Code scanning is still expecting 1 result from CodeQL for `a71e5c9` or `cdd69f7`.

## Change

Add an optional `pre-build-cmd` input modeled after [`go-check.yml`](https://github.com/netresearch/.github/blob/main/.github/workflows/go-check.yml). Runs **after** CodeQL `init` (Go is already on `PATH`) and **before** `analyze` invokes the autobuilder, so generators see a complete module tree.

```yaml
jobs:
  codeql:
    uses: netresearch/.github/.github/workflows/codeql.yml@main
    with:
      languages: auto
      pre-build-cmd: |
        go install github.com/a-h/templ/cmd/templ@\$(go list -m -f '{{.Version}}' github.com/a-h/templ)
        templ generate
```

Backward compatible: new input defaults to `''` and the step is conditional via `if:`. Existing callers (this repo's own CodeQL workflow, every Go repo using `languages: auto`) are unaffected.

## Test plan

- [ ] CI on this PR passes
- [ ] Caller test: open a follow-up PR on `netresearch/ldap-manager` that uses `pre-build-cmd: |` to run `templ generate` and confirm the standalone `CodeQL` check no longer goes `NEUTRAL`