### PR TITLE
ci(scorecard-template): drop top-level read-all permissions

### DIFF
--- a/templates/go-app/.github/workflows/scorecard.yml
+++ b/templates/go-app/.github/workflows/scorecard.yml
@@ -7,7 +7,8 @@ on:
     - cron: '0 0 * * 0'
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   scorecard:

--- a/templates/go-app/.github/workflows/scorecard.yml
+++ b/templates/go-app/.github/workflows/scorecard.yml
@@ -7,8 +7,7 @@ on:
     - cron: '0 0 * * 0'
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   scorecard:

--- a/templates/go-lib/.github/workflows/scorecard.yml
+++ b/templates/go-lib/.github/workflows/scorecard.yml
@@ -7,7 +7,7 @@ on:
     - cron: '0 0 * * 0'
   workflow_dispatch:
 
-permissions: read-all
+permissions: {}
 
 jobs:
   scorecard:


### PR DESCRIPTION
## Summary

`permissions: read-all` at the top level of the Scorecard workflow is flagged by Sonar `githubactions:S8234` ("Read-all and Write-all permissions should not be used"). The job already redefines the per-permission scopes it needs (`contents`, `security-events`, `id-token`, `actions`), so the top-level only needs the minimum required to checkout the repo.

Mirrors the consumer-side fix landing in [netresearch/ofelia#664](https://github.com/netresearch/ofelia/pull/664). Once this template change merges, the drift check on that PR will resolve.

## Test plan

- [ ] Template drift remains green for other consumers (the template just removes a broader-than-needed permission grant; nothing in any job depended on `read-all`)
- [ ] Scorecard workflow continues to run successfully on next scheduled execution in consumer repos