### PR TITLE
fix(release-go-app): use .sigstore.json extension for cosign signatures

### DIFF
--- a/.github/workflows/release-go-app.yml
+++ b/.github/workflows/release-go-app.yml
@@ -125,7 +125,7 @@ on:
         type: boolean
         default: true
       sign-artifacts:
-        description: "Per-asset cosign sign-blob → .bundle file alongside each binary/SBOM."
+        description: "Per-asset cosign sign-blob → .sigstore.json file alongside each binary/SBOM. Extension chosen so OSSF Scorecard's signed-releases probe recognises it; the content is cosign's Sigstore bundle JSON (cert + sig + Rekor inclusion proof)."
         required: false
         type: boolean
         default: true
@@ -674,7 +674,7 @@ jobs:
           files=()
           for f in *; do
             case "$f" in
-              checksums.txt|*.bundle) continue ;;
+              checksums.txt|*.sigstore.json) continue ;;
               *) [[ -f "$f" ]] && files+=("$f") ;;
             esac
           done
@@ -698,8 +698,12 @@ jobs:
           for f in *; do
             [[ -f "$f" ]] || continue
             case "$f" in
-              *.bundle) continue ;;
-              *) cosign sign-blob --yes "$f" --bundle "${f}.bundle" ;;
+              *.sigstore.json) continue ;;
+              # Use .sigstore.json (Sigstore bundle format) so OSSF Scorecard
+              # signed-releases probe recognises the signatures. The bundle
+              # content is identical to cosign's --bundle output; only the
+              # extension differs.
+              *) cosign sign-blob --yes "$f" --bundle "${f}.sigstore.json" ;;
             esac
           done
           ls -lah
@@ -750,7 +754,7 @@ jobs:
               echo ""
               echo '```bash'
               echo "cosign verify-blob \\"
-              echo "  --bundle ${APP}-linux-amd64.bundle \\"
+              echo "  --bundle ${APP}-linux-amd64.sigstore.json \\"
               echo "  --certificate-identity-regexp \"https://github.com/${OWNER}/.*\" \\"
               echo "  --certificate-oidc-issuer \"https://token.actions.githubusercontent.com\" \\"
               echo "  ${APP}-linux-amd64"
@@ -760,7 +764,7 @@ jobs:
               echo ""
               echo '```bash'
               echo "cosign verify-blob \\"
-              echo "  --bundle checksums.txt.bundle \\"
+              echo "  --bundle checksums.txt.sigstore.json \\"
               echo "  --certificate-identity-regexp \"https://github.com/${OWNER}/.*\" \\"
               echo "  --certificate-oidc-issuer \"https://token.actions.githubusercontent.com\" \\"
               echo "  checksums.txt"


### PR DESCRIPTION
## Summary

OSSF Scorecard's `signed-releases` probe scores `0/high` for every consumer of `release-go-app.yml` despite every release asset shipping a valid Sigstore bundle. Root cause: the probe is purely suffix-based and the recognised extensions are:

> `.asc`, `.minisig`, `.sig`, `.sign`, `.sigstore`, `.sigstore.json`

— see [`ossf/scorecard probes/releasesAreSigned/impl.go#L43`](https://github.com/ossf/scorecard/blob/main/probes/releasesAreSigned/impl.go#L43).

We were emitting `.bundle` (cosign's `--bundle` default file name), which is not in that list.

## Change

Rename the output of `cosign sign-blob --bundle "${f}.bundle"` to `"${f}.sigstore.json"`. The bundle content is **identical** — still cosign's Sigstore bundle JSON (cert + signature + Rekor inclusion proof in one self-contained file). Only the filename extension changes.

Verification still works without any caller change:

```bash
cosign verify-blob --bundle ofelia-linux-amd64.sigstore.json …
```

Also updated:

- the `sign-artifacts` input description
- the checksum-list `case` filter (so the new `.sigstore.json` files are skipped when generating `checksums.txt`)
- the release-body verification snippet (so the embedded `cosign verify-blob` example references the right filename)

## Impact

- **Consumers**: ofelia, ldap-manager and any other `release-go-app.yml` consumer get a passing Scorecard `Signed-Releases` score on their next tag.
- **Existing releases**: unaffected (already published, immutable). Historical `.bundle` assets remain valid Sigstore bundles, just unrecognised by Scorecard.
- **Sibling workflows**: `typo3-ci-workflows/release.yml` and `typo3-ci-workflows/release-typo3-extension.yml` already use `.sigstore.json` — no change needed. `skill-repo-skill/release.yml` has the same bug; fix opened in parallel.

## Test plan

- [ ] CI passes (yaml-lint, action-lint via reusable workflow gates)
- [ ] Next `release-go-app.yml` consumer release publishes `*.sigstore.json` instead of `*.bundle`
- [ ] Re-run OSSF Scorecard on a consumer repo after the next release → `Signed-Releases` score moves from 0 to non-zero

## Reference

- ofelia v0.25.1 Scorecard report flagged this: every binary `not signed` + `no provenance`.
- Per-binary cosign signatures and SBOMs were always present — only the suffix was wrong.