### PR TITLE
fix(golib-create-release): switch to Sigstore bundle format

### DIFF
--- a/.github/workflows/golib-create-release.yml
+++ b/.github/workflows/golib-create-release.yml
@@ -176,9 +176,17 @@ jobs:
       - name: Sign checksums with Cosign (keyless)
         if: inputs.cosign-sign
         run: |
+          # Cosign v3+ emits a single self-contained Sigstore bundle (cert +
+          # signature + Rekor inclusion proof) via --bundle. The legacy two-file
+          # output (--output-certificate / --output-signature) is deprecated and
+          # silently ignored when --new-bundle-format is the default.
+          #
+          # Use .sigstore.json extension so OSSF Scorecard's signed-releases
+          # probe recognises the signature (allowlist: .asc, .minisig, .sig,
+          # .sign, .sigstore, .sigstore.json). The bundle content is identical
+          # to cosign's --bundle default output; only the filename differs.
           cosign sign-blob --yes \
-            --output-certificate checksums.txt.pem \
-            --output-signature checksums.txt.sig \
+            --bundle checksums.txt.sigstore.json \
             checksums.txt
 
       - name: Verify Cosign signature
@@ -187,8 +195,7 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           cosign verify-blob \
-            --certificate checksums.txt.pem \
-            --signature checksums.txt.sig \
+            --bundle checksums.txt.sigstore.json \
             --certificate-identity-regexp "https://github.com/${REPO}/*" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
             checksums.txt
@@ -218,7 +225,6 @@ jobs:
           files: |
             sbom-*.json
             checksums.txt
-            checksums.txt.sig
-            checksums.txt.pem
+            checksums.txt.sigstore.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Modernize \`golib-create-release.yml\` to match the rest of the netresearch release pipeline. Switch cosign signing from the **legacy two-file output** (\`--output-certificate\`+\`--output-signature\` → \`.pem\` + \`.sig\`) to the **single-file Sigstore bundle** (\`--bundle\` → \`.sigstore.json\`).

## Why

Three reasons converging:

1. **Cosign deprecation.** \`--output-certificate\` / \`--output-signature\` are deprecated in cosign v3+ and silently ignored once \`--new-bundle-format\` becomes the default. The Sigstore bundle (cert + signature + Rekor inclusion proof in one JSON file) is the canonical output.
2. **Consistency.** Every other netresearch release workflow already uses \`.sigstore.json\`:
   - \`release-go-app.yml\` (after #129)
   - \`typo3-ci-workflows/release.yml\` + \`release-typo3-extension.yml\`
   - \`skill-repo-skill/release.yml\` (after netresearch/skill-repo-skill#102)
   This was the last outlier.
3. **Cleaner verification UX.** One argument instead of two:
   \`\`\`bash
   # Before
   cosign verify-blob --certificate checksums.txt.pem \\
                       --signature   checksums.txt.sig …
   # After
   cosign verify-blob --bundle checksums.txt.sigstore.json …
   \`\`\`

## Impact

| | Before | After |
|---|---|---|
| Release assets attached | \`checksums.txt\` + \`checksums.txt.pem\` + \`checksums.txt.sig\` | \`checksums.txt\` + \`checksums.txt.sigstore.json\` |
| OSSF Scorecard recognition | ✅ (\`.sig\` on allowlist) | ✅ (\`.sigstore.json\` on allowlist) |
| Cosign CLI flags | Deprecated (v3+) | Current |
| Past releases | Unaffected (immutable; \`cosign verify-blob --certificate … --signature …\` still works) | — |

## Consumers

Go libraries that call this reusable workflow — e.g. \`simple-ldap-go\`, \`go-cron\`. Their next release will publish the new \`.sigstore.json\` asset instead of the \`.pem\` + \`.sig\` pair.

## Test plan

- [ ] CI passes (yamllint, actionlint via reusable workflow gates)
- [ ] Next release of a go-lib consumer publishes \`checksums.txt.sigstore.json\`
- [ ] \`cosign verify-blob --bundle checksums.txt.sigstore.json …\` succeeds against the new release

## Related

- #129 — same \`.bundle\` → \`.sigstore.json\` work in \`release-go-app.yml\`
- #130 — cleanup of the older deprecated workflows in the same area