### PR TITLE
fix(workflows/lock): bump dessant/lock-threads v6.0.0 → v6.0.2

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: dessant/lock-threads@7266a7ce5c1df01b1c6db85bf8cd86c737dadbe7 # v6.0.0
+      - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c # v6.0.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           issue-inactive-days: ${{ inputs.issue-inactive-days }}


### PR DESCRIPTION
## Summary

Bumps `dessant/lock-threads` from [`v6.0.0`](https://github.com/dessant/lock-threads/releases/tag/v6.0.0) to [`v6.0.2`](https://github.com/dessant/lock-threads/releases/tag/v6.0.2) in `.github/workflows/lock.yml` to fix a GITHUB_TOKEN validation regression that is breaking the daily `Community` workflow run across every NR repo that consumes `lock.yml@main`.

## Root cause

GitHub recently changed the `GITHUB_TOKEN` format to a longer string. `dessant/lock-threads@v6.0.0` (currently pinned) has a hardcoded schema validation that rejects tokens longer than 100 characters:

```
##[error]"github-token" length must be less than or equal to 100 characters long
```

This breaks every consumer of [`netresearch/.github/.github/workflows/lock.yml@main`](https://github.com/netresearch/.github/blob/main/.github/workflows/lock.yml) on every scheduled cron run (00:00 UTC daily). Observed today (2026-05-23) on at least:

- [`netresearch/t3x-nr-textdb` Community #91](https://github.com/netresearch/t3x-nr-textdb/actions/runs/26318591202)
- [`netresearch/t3x-nr-temporal-cache` Community #91](https://github.com/netresearch/t3x-nr-temporal-cache/actions/runs/26318520167)
- [`netresearch/t3x-nr-image-optimize` Community #146](https://github.com/netresearch/t3x-nr-image-optimize/actions/runs/26318355355)

The full blast radius is every NR repo whose Community workflow calls `lock.yml@main` — ~30 repos.

## Why v6.0.2 is the fix

From [the upstream CHANGELOG entry for v6.0.2](https://github.com/dessant/lock-threads/blob/main/CHANGELOG.md#602-2026-05-23):

> ### Bug Fixes
> * **update github-token validation schema** ([a329c89](https://github.com/dessant/lock-threads/commit/a329c89d09f15f65ee0fc0c36ed36f957598ff68)), closes [#55](https://github.com/dessant/lock-threads/issues/55)

Released **today (2026-05-23)** specifically to address this. v6.0.1 (released 2026-05-21) only updated dependencies and doesn't fix the schema.

## Pin

`dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c # v6.0.2` — commit SHA the `v6.0.2` tag points to, resolved via `gh api repos/dessant/lock-threads/git/refs/tags/v6.0.2`. Renovate will keep this current via the standard `# vX.Y.Z` comment pattern.

## Verification

- `actionlint .github/workflows/lock.yml` → clean
- `yamllint` against CI defaults → clean
- SHA confirmed to point at commit "chore(release): 6.0.2" dated 2026-05-23

After merge, the daily 00:00 UTC Community runs across consuming repos should self-correct on the next scheduled trigger.