### PR TITLE
chore(ci): add zizmor config + fix template-injection and dependabot cooldown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,10 @@ jobs:
   yaml:
     name: Lint YAML
     uses: ./.github/workflows/lint-yaml.yml
+
+  zizmor:
+    name: zizmor
+    permissions:
+      contents: read
+      security-events: write
+    uses: ./.github/workflows/zizmor.yml

--- a/.github/workflows/node-audit.yml
+++ b/.github/workflows/node-audit.yml
@@ -91,19 +91,27 @@ jobs:
 
       - name: Run audit (bun)
         if: inputs.package-manager == 'bun'
+        env:
+          AUDIT_LEVEL: ${{ inputs.audit-level }}
         run: |
           bun install --frozen-lockfile
           npm i --package-lock-only
-          npm audit --audit-level=${{ inputs.audit-level }}
+          npm audit --audit-level="$AUDIT_LEVEL"
 
       - name: Run audit (pnpm)
         if: inputs.package-manager == 'pnpm'
-        run: pnpm audit --audit-level=${{ inputs.audit-level }}
+        env:
+          AUDIT_LEVEL: ${{ inputs.audit-level }}
+        run: pnpm audit --audit-level="$AUDIT_LEVEL"
 
       - name: Run audit (npm)
         if: inputs.package-manager == 'npm'
-        run: npm audit --audit-level=${{ inputs.audit-level }}
+        env:
+          AUDIT_LEVEL: ${{ inputs.audit-level }}
+        run: npm audit --audit-level="$AUDIT_LEVEL"
 
       - name: Run audit (yarn)
         if: inputs.package-manager == 'yarn'
-        run: yarn npm audit --severity ${{ inputs.audit-level }}
+        env:
+          AUDIT_LEVEL: ${{ inputs.audit-level }}
+        run: yarn npm audit --severity "$AUDIT_LEVEL"

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,60 @@
+name: zizmor
+
+# Reusable zizmor (https://zizmor.sh) static analysis for GitHub Actions.
+#
+# Report-only by design: zizmor runs in SARIF mode (exit 0 regardless of
+# findings) and the results are uploaded to the repository's code-scanning
+# / Security tab, exactly like the CodeQL and Scorecard reusables. Findings
+# surface as code-scanning alerts; they do NOT fail CI. zizmor automatically
+# discovers a repo's `.github/zizmor.yml` config when present.
+#
+# Skipped on `merge_group`: the gh-readonly-queue ref is deleted the moment
+# the queue completes, which races the SARIF upload (cf. scorecard.yml).
+
+on:
+  workflow_call:
+    inputs:
+      inputs:
+        description: Whitespace-separated paths for zizmor to audit.
+        type: string
+        default: "."
+      persona:
+        description: "Audit persona: regular | pedantic | auditor."
+        type: string
+        default: regular
+      zizmor-version:
+        description: Exact zizmor version (X.Y.Z) or 'latest'.
+        type: string
+        default: "1.25.2"
+
+permissions: {}
+
+jobs:
+  analyze:
+    name: zizmor analysis
+    if: github.event_name != 'merge_group'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          inputs: ${{ inputs.inputs }}
+          persona: ${{ inputs.persona }}
+          version: ${{ inputs.zizmor-version }}
+          # advanced-security (default true) emits SARIF and uploads it to
+          # code scanning. zizmor exits 0 in SARIF mode, so this is report-
+          # only and never blocks CI.

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,13 @@
+# zizmor (https://zizmor.sh) configuration
+#
+# Tunes zizmor to Netresearch conventions so the audit reports only
+# actionable findings. Third-party actions remain hash-pin enforced.
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # First-party reusable workflows track @main by policy and are
+        # never SHA-pinned, so fixes propagate to all consumers.
+        "netresearch/*": ref-pin
+        # Everything else must be pinned to a full commit SHA.
+        "*": hash-pin

--- a/templates/go-app/.github/dependabot.yml
+++ b/templates/go-app/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     groups:
       go-dependencies:
         patterns: ['*']
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: github-actions
     directory: /
@@ -19,6 +21,8 @@ updates:
     groups:
       github-actions:
         patterns: ['*']
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: docker
     directory: /
@@ -29,6 +33,8 @@ updates:
     groups:
       docker:
         patterns: ['*']
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: npm
     directory: /
@@ -39,6 +45,8 @@ updates:
     groups:
       npm:
         patterns: ['*']
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: devcontainers
     directory: /
@@ -49,3 +57,5 @@ updates:
     groups:
       devcontainers:
         patterns: ['*']
+    cooldown:
+      default-days: 7

--- a/templates/go-lib/.github/dependabot.yml
+++ b/templates/go-lib/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     groups:
       go-dependencies:
         patterns: ['*']
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: github-actions
     directory: /
@@ -19,6 +21,8 @@ updates:
     groups:
       github-actions:
         patterns: ['*']
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: docker
     directory: /
@@ -29,3 +33,5 @@ updates:
     groups:
       docker:
         patterns: ['*']
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Adds a [zizmor](https://zizmor.sh) config tuned to NR conventions and fixes the genuinely actionable findings a baseline audit surfaced.

## Changes

**`.github/zizmor.yml` (new)** — `unpinned-uses` uses the `ref-pin` policy for first-party `netresearch/*` refs (they track `@main` by standing convention so fixes propagate); all third-party actions remain `hash-pin` enforced. This removes the bulk of the noise: of 32 baseline "high" findings, 23 were first-party `@main` refs.

**`node-audit.yml` — template injection (4×, HIGH)** — `${{ inputs.audit-level }}` was interpolated directly into `run:` blocks. Now bound to an `env:` var and referenced as `"$AUDIT_LEVEL"`. Behaviour-preserving.

**`templates/go-app` & `templates/go-lib` `dependabot.yml` — cooldown (8×, MEDIUM)** — added `cooldown: { default-days: 7 }` to every ecosystem, mitigating pulls of freshly-published malicious releases. Fixing the **templates** propagates the hardening to every generated repo.

## Result

`zizmor .github/workflows/ templates/`: **32→5 high, 8→0 medium**.

## Out of scope (follow-ups)

Remaining 5 highs are review items, not blind fixes:
- `pull_request_target` in `templates/go-app` auto-merge-deps/labeler — required for fork-PR automation; needs a confirm-then-annotate pass.
- `cache-poisoning` (low confidence) on `setup-go` cache in `golib-create-release.yml`.

Verified locally with `actionlint` (node-audit.yml passes).