### PR TITLE
ci(go-lib): grant id-token and attestations to release caller template

### DIFF
--- a/templates/go-lib/.github/workflows/release.yml
+++ b/templates/go-lib/.github/workflows/release.yml
@@ -12,3 +12,5 @@ jobs:
     uses: netresearch/.github/.github/workflows/golib-create-release.yml@main
     permissions:
       contents: write
+      id-token: write
+      attestations: write


### PR DESCRIPTION
## Problem

The `go-lib` release.yml caller template grants only `contents: write`, but the `golib-create-release` reusable workflow's `release` job requests `id-token: write` (cosign keyless) and `attestations: write` (added in #16). A called reusable workflow cannot request more permissions than the calling job grants, so the run **fails at startup**.

This was observed on **netresearch/go-cron v0.15.0** — the first release tag in a go-lib repo since the reusable-workflow migration. Its Release workflow startup-failed with "workflow file issue".

## Fix

Grant the go-lib caller `id-token: write` and `attestations: write` in addition to `contents: write` — mirroring the `go-app` template, which already has all three.

## Impact

Affects every repo consuming the `go-lib` template's release workflow. After merge, those repos pick up the fix on their next template sync.