### PR TITLE
fix(golib-release): verify cosign signature against reusable workflow identity

### DIFF
--- a/.github/workflows/golib-create-release.yml
+++ b/.github/workflows/golib-create-release.yml
@@ -191,12 +191,13 @@ jobs:
 
       - name: Verify Cosign signature
         if: inputs.cosign-sign
-        env:
-          REPO: ${{ github.repository }}
         run: |
+          # Keyless signing inside a reusable workflow carries the REUSABLE
+          # workflow's identity (its job_workflow_ref), not the calling repo's.
+          # Verify against this workflow's identity rather than github.repository.
           cosign verify-blob \
             --bundle checksums.txt.sigstore.json \
-            --certificate-identity-regexp "https://github.com/${REPO}/*" \
+            --certificate-identity-regexp "^https://github\.com/netresearch/\.github/\.github/workflows/golib-create-release\.yml@" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
             checksums.txt
 


### PR DESCRIPTION
## Problem

The `golib-create-release` reusable workflow's **Verify Cosign signature** step uses `--certificate-identity-regexp "https://github.com/${github.repository}/*"` (the calling repo). But keyless signing performed *inside a reusable workflow* yields a certificate whose SAN identity is the **reusable workflow's** `job_workflow_ref`, not the caller. So verification fails:

```
failed to verify certificate identity: no matching CertificateIdentity found,
last error: expected SAN value to match regex "https://github.com/netresearch/go-cron/*",
got "https://github.com/netresearch/.github/.github/workflows/golib-create-release.yml@refs/heads/main"
```

Observed on **netresearch/go-cron v0.15.0** — the first release to actually run cosign signing (prior releases couldn't even start the workflow until the caller perms were fixed in #163).

## Fix

Verify against this workflow's own identity:

```
--certificate-identity-regexp "^https://github\.com/netresearch/\.github/\.github/workflows/golib-create-release\.yml@"
```

## Follow-up (not in this PR)

Downstream verification instructions in consuming repos' release notes should likewise reference the reusable-workflow identity rather than the per-repo identity.