### PR TITLE
ci(dependabot): declare only ecosystems consumers have; make extras opt-in

### DIFF
--- a/templates/go-app/.github/dependabot.yml
+++ b/templates/go-app/.github/dependabot.yml
@@ -12,17 +12,27 @@
 # Opt-in npm:
 #   - package-ecosystem: npm
 #     directory: /
-#     schedule: { interval: weekly, day: monday }
+#     schedule:
+#       interval: weekly
+#       day: monday
 #     open-pull-requests-limit: 5
-#     groups: { npm: { patterns: ['*'] } }
-#     cooldown: { default-days: 7 }
+#     groups:
+#       npm:
+#         patterns: ['*']
+#     cooldown:
+#       default-days: 7
 # Opt-in devcontainers:
 #   - package-ecosystem: devcontainers
 #     directory: /
-#     schedule: { interval: weekly, day: monday }
+#     schedule:
+#       interval: weekly
+#       day: monday
 #     open-pull-requests-limit: 2
-#     groups: { devcontainers: { patterns: ['*'] } }
-#     cooldown: { default-days: 7 }
+#     groups:
+#       devcontainers:
+#         patterns: ['*']
+#     cooldown:
+#       default-days: 7
 version: 2
 updates:
   - package-ecosystem: gomod

--- a/templates/go-app/.github/dependabot.yml
+++ b/templates/go-app/.github/dependabot.yml
@@ -1,3 +1,28 @@
+# Managed by netresearch/.github/templates/go-app/
+#
+# Declares only the ecosystems every go-app consumer is guaranteed to have:
+# gomod, github-actions, and docker (all go-app repos ship a Dockerfile).
+#
+# npm and devcontainers are OPT-IN: a repo that actually has a package.json
+# or a devcontainer adds the block below to its own dependabot.yml and lists
+# `.github/dependabot.yml` under `intentional-drift:` in .github/template.yaml
+# so the template sync stops managing the file. Declaring an ecosystem without
+# its manifest makes the Dependabot run fail with `dependency_file_not_found`.
+#
+# Opt-in npm:
+#   - package-ecosystem: npm
+#     directory: /
+#     schedule: { interval: weekly, day: monday }
+#     open-pull-requests-limit: 5
+#     groups: { npm: { patterns: ['*'] } }
+#     cooldown: { default-days: 7 }
+# Opt-in devcontainers:
+#   - package-ecosystem: devcontainers
+#     directory: /
+#     schedule: { interval: weekly, day: monday }
+#     open-pull-requests-limit: 2
+#     groups: { devcontainers: { patterns: ['*'] } }
+#     cooldown: { default-days: 7 }
 version: 2
 updates:
   - package-ecosystem: gomod
@@ -32,30 +57,6 @@ updates:
     open-pull-requests-limit: 3
     groups:
       docker:
-        patterns: ['*']
-    cooldown:
-      default-days: 7
-
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: weekly
-      day: monday
-    open-pull-requests-limit: 5
-    groups:
-      npm:
-        patterns: ['*']
-    cooldown:
-      default-days: 7
-
-  - package-ecosystem: devcontainers
-    directory: /
-    schedule:
-      interval: weekly
-      day: monday
-    open-pull-requests-limit: 2
-    groups:
-      devcontainers:
         patterns: ['*']
     cooldown:
       default-days: 7

--- a/templates/go-lib/.github/dependabot.yml
+++ b/templates/go-lib/.github/dependabot.yml
@@ -1,3 +1,20 @@
+# Managed by netresearch/.github/templates/go-lib/
+#
+# Declares only the ecosystems every go-lib consumer is guaranteed to have:
+# gomod and github-actions. Libraries don't ship a Dockerfile, so docker is
+# NOT declared by default — declaring an ecosystem without its manifest makes
+# the Dependabot run fail with `dependency_file_not_found`.
+#
+# docker (or npm/devcontainers) is OPT-IN: a library that genuinely has the
+# manifest adds the block to its own dependabot.yml and lists
+# `.github/dependabot.yml` under `intentional-drift:` in .github/template.yaml
+# so the template sync stops managing the file. Example:
+#   - package-ecosystem: docker
+#     directory: /
+#     schedule: { interval: weekly, day: monday }
+#     open-pull-requests-limit: 3
+#     groups: { docker: { patterns: ['*'] } }
+#     cooldown: { default-days: 7 }
 version: 2
 updates:
   - package-ecosystem: gomod
@@ -20,18 +37,6 @@ updates:
     open-pull-requests-limit: 5
     groups:
       github-actions:
-        patterns: ['*']
-    cooldown:
-      default-days: 7
-
-  - package-ecosystem: docker
-    directory: /
-    schedule:
-      interval: weekly
-      day: monday
-    open-pull-requests-limit: 3
-    groups:
-      docker:
         patterns: ['*']
     cooldown:
       default-days: 7

--- a/templates/go-lib/.github/dependabot.yml
+++ b/templates/go-lib/.github/dependabot.yml
@@ -11,10 +11,15 @@
 # so the template sync stops managing the file. Example:
 #   - package-ecosystem: docker
 #     directory: /
-#     schedule: { interval: weekly, day: monday }
+#     schedule:
+#       interval: weekly
+#       day: monday
 #     open-pull-requests-limit: 3
-#     groups: { docker: { patterns: ['*'] } }
-#     cooldown: { default-days: 7 }
+#     groups:
+#       docker:
+#         patterns: ['*']
+#     cooldown:
+#       default-days: 7
 version: 2
 updates:
   - package-ecosystem: gomod


### PR DESCRIPTION
Several consumers fail their weekly Dependabot runs with `dependency_file_not_found` because the templates declare ecosystems the repo has no manifest for. (Surfaced when the `cooldown` sync PRs merged and triggered immediate re-runs — the `cooldown` change itself is valid and unrelated.)

## Manifest reality across the fleet

| repo | template | gomod | docker | npm | devcontainers |
|---|---|:--:|:--:|:--:|:--:|
| ofelia | go-app | ✓ | ✓ | — | ✓ |
| ldap-manager | go-app | ✓ | ✓ | — | ✓ |
| ldap-selfservice-password-changer | go-app | ✓ | ✓ | ✓ | — |
| raybeam | go-app | ✓ | ✓ | — | — |
| simple-ldap-go | go-lib | ✓ | — | — | — |
| go-cron | go-lib | ✓ | — | — | — |

Failing runs observed: npm in ofelia/ldap-manager/raybeam (no `package.json`), devcontainers in raybeam (no devcontainer), docker in simple-ldap-go (no `Dockerfile`).

## Change

- **go-app** declares `gomod + github-actions + docker` (all go-app repos ship a Dockerfile). Drops `npm` + `devcontainers`.
- **go-lib** declares `gomod + github-actions`. Drops `docker` (libraries have no Dockerfile).
- `cooldown: default-days: 7` preserved on every remaining ecosystem.
- Each template header documents the opt-in block + `intentional-drift` procedure for repos that genuinely have the extra manifest.

## Follow-up after this merges (consumer side)

Opt-ins (preserve currently-working coverage — add the ecosystem to the repo dependabot.yml + list `.github/dependabot.yml` under `intentional-drift:`):
- `ldap-selfservice-password-changer` → npm
- `ldap-manager` → devcontainers
- `ofelia` → devcontainers

Plain re-sync drops the dead ecosystems (no opt-in needed):
- `raybeam` (npm + devcontainers), `simple-ldap-go` (docker), `go-cron` (docker already absent)

## Test plan

- [ ] Reviewer confirms the per-template ecosystem set matches the matrix above.
- [ ] After merge: open the consumer opt-in PRs, then re-sync the rest; verify each repo's `event=dynamic` Dependabot runs go green (no `dependency_file_not_found`).