### PR TITLE
docs(agents): add AGENTS.md with template-drift sync reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# Agent Guide — netresearch/.github
+
+Organization-level community health files, reusable GitHub Actions workflows,
+and the canonical Go repository templates (`templates/go-app`, `templates/go-lib`)
+that consumer repos are kept in sync with.
+
+## Template-drift sync
+
+The `go-app` and `go-lib` templates under `templates/` are the source of truth
+for each consumer repo's `.github/` tree. Drift between a consumer and its
+template is detected and reconciled by dedicated tooling:
+
+- **Detect:** `.github/workflows/drift-scan.yml` runs weekly (Mon 06:00 UTC) and
+  on `workflow_dispatch` (with an optional space-separated `repos:` input). It
+  auto-opens "Template drift: \<repo\> vs \<go-app|go-lib\>" issues and
+  auto-closes them once drift is gone — so after merging fixes, dispatch the
+  scan to close immediately instead of waiting for the next schedule.
+- **Fix:** `scripts/sync-template.sh <go-app|go-lib> netresearch/<repo>`
+  SSH-clones the consumer, copies the template `.github/` tree, commits with
+  `-S --signoff`, pushes a `sync/...` branch, and opens a PR. Only drifting
+  files change. `template.yaml` is created on first sync only and never
+  overwritten — it carries each repo's `intentional-drift:` state.
+- **Scope:** keep templates trimmed to a universal core (gomod + github-actions);
+  per-repo extras (docker, npm, devcontainers) are opt-in via a self-managed
+  `dependabot.yml` plus `intentional-drift`, because not every consumer has
+  those manifests and an undeclared ecosystem fails Dependabot with
+  `dependency_file_not_found`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,16 +12,18 @@ template is detected and reconciled by dedicated tooling:
 
 - **Detect:** `.github/workflows/drift-scan.yml` runs weekly (Mon 06:00 UTC) and
   on `workflow_dispatch` (with an optional space-separated `repos:` input). It
-  auto-opens "Template drift: \<repo\> vs \<go-app|go-lib\>" issues and
+  auto-opens `Template drift: <repo> vs <go-app|go-lib>` issues and
   auto-closes them once drift is gone — so after merging fixes, dispatch the
   scan to close immediately instead of waiting for the next schedule.
 - **Fix:** `scripts/sync-template.sh <go-app|go-lib> netresearch/<repo>`
   SSH-clones the consumer, copies the template `.github/` tree, commits with
   `-S --signoff`, pushes a `sync/...` branch, and opens a PR. Only drifting
-  files change. `template.yaml` is created on first sync only and never
+  files change. `.github/template.yaml` is created on first sync only and never
   overwritten — it carries each repo's `intentional-drift:` state.
-- **Scope:** keep templates trimmed to a universal core (gomod + github-actions);
-  per-repo extras (docker, npm, devcontainers) are opt-in via a self-managed
+- **Scope:** templates declare only the ecosystems every consumer is guaranteed
+  to have. `go-lib` baselines `gomod + github-actions`; `go-app` adds `docker`
+  on top (every go-app repo ships a Dockerfile). Further extras — `npm`,
+  `devcontainers`, and `docker` for `go-lib` — are opt-in via a self-managed
   `dependabot.yml` plus `intentional-drift`, because not every consumer has
   those manifests and an undeclared ecosystem fails Dependabot with
   `dependency_file_not_found`.


### PR DESCRIPTION
Create the repo's first AGENTS.md with a brief header and a Template-drift sync section documenting the durable, repo-specific workflow:

- `drift-scan.yml` (weekly Mon 06:00 UTC + `workflow_dispatch` with `repos:` input) auto-opens and auto-closes template-drift issues.
- `scripts/sync-template.sh <go-app|go-lib> netresearch/<repo>` reconciles a consumer's `.github/` tree (signed + DCO, opens a PR), never overwriting `template.yaml`.
- Universal-core dependabot scoping (gomod + github-actions) with per-repo opt-in extras to avoid `dependency_file_not_found`.

Verified against the live scripts/workflows in this repo. Migrated from project memory as part of the 2026-06-03 memory cleanup.