### PR TITLE
ci(templates): run CodeQL on merge_group for go-app and go-lib

### DIFF
--- a/templates/go-app/.github/workflows/codeql.yml
+++ b/templates/go-app/.github/workflows/codeql.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
   schedule:
     - cron: '30 4 * * 1'
 

--- a/templates/go-lib/.github/workflows/codeql.yml
+++ b/templates/go-lib/.github/workflows/codeql.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
   schedule:
     - cron: '30 4 * * 1'
 


### PR DESCRIPTION
## Problem

Both the `go-app` and `go-lib` templates configure a **merge queue** (`ci.yml` triggers on `merge_group`) and their default ruleset requires **code scanning** results. But `codeql.yml` only triggered on `push` / `pull_request` / `schedule` — never `merge_group`.

GitHub requires the code-scanning workflow to run on `merge_group` when a merge queue gates on it. Without it, CodeQL never runs for the merge-queue commit, so GitHub permanently reports:

```
Code scanning is still expecting 1 result from CodeQL for <merge-sha> or <head-sha>
```

The result: **every Renovate/Dependabot PR in consumer repos is unmergeable** and only lands via an admin bypass. Seen repeatedly on netresearch/ldap-manager (#607, #608).

## Fix

Add the `merge_group` trigger to both `codeql.yml` callers, mirroring `ci.yml`. The reusable `codeql.yml` is `workflow_call` with only input-based `if:` conditions, so it runs unchanged from a `merge_group` caller — no other changes needed.

## After merge

Consumers need a template sync (`scripts/sync-template.sh`) to pick up the new trigger; until then their drift check will flag `codeql.yml`.